### PR TITLE
Add find or create support for apps

### DIFF
--- a/lib/appUids.js
+++ b/lib/appUids.js
@@ -1,12 +1,31 @@
 'use strict';
 
-const { getApp } = require('@serverless/platform-sdk');
+const { getApp, createApp, getAccessKeyForTenant } = require('@serverless/platform-sdk');
 
 module.exports = async function (orgName, appName) {
-  const app = await getApp({
-    tenant: orgName,
-    app: appName,
-  });
+  let app = {};
+  try {
+    app = await getApp({
+      tenant: orgName,
+      app: appName,
+    });
+  } catch (e) {
+    try {
+      const parsed = JSON.parse(e.message);
+      if (parsed.errorMessage.startsWith('Application not found')) {
+        const token = await getAccessKeyForTenant(orgName);
+        app = await createApp({
+          tenant: orgName,
+          app: appName,
+          token,
+        });
+      } else {
+        throw e;
+      }
+    } catch (jsonParseError) {
+      throw e;
+    }
+  }
 
   return {
     appUid: app.appUid,


### PR DESCRIPTION
Catches a 404 and calls createApp.

If we can't parse the response, it must be an error other than 404, so we re-throw it. Unfortunately our error handling in platform-sdk overwrites the status code, so this code is a little hacky. Hopefully we can fix this after we deprecate the old sdk!