### PR TITLE
Include AWS region name in CF resource name of CW log subscription filter

### DIFF
--- a/lib/logsCollection.js
+++ b/lib/logsCollection.js
@@ -19,6 +19,13 @@ const {
 
 const { getPlatformClientWithAccessKey } = require('./clientUtils');
 
+const formatRegionName = (regionName) => {
+  return regionName
+    .split('-')
+    .map((part) => upperFirst(part))
+    .join('');
+};
+
 module.exports = async (ctx) => {
   if (
     ctx.sls.service.custom &&
@@ -100,7 +107,9 @@ module.exports = async (ctx) => {
       filterPattern = API_GATEWAY_V2_FILTER_PATTERN;
     }
 
-    template.Resources[`CloudWatchLogsSubscriptionFilter${upperFirst(logGroupKey)}`] = {
+    template.Resources[
+      `CWLSubFilter${upperFirst(logGroupKey)}${formatRegionName(destinationOpts.regionName)}`
+    ] = {
       Type: 'AWS::Logs::SubscriptionFilter',
       Properties: {
         DestinationArn: destinationArn,

--- a/lib/logsCollection.test.js
+++ b/lib/logsCollection.test.js
@@ -93,7 +93,7 @@ describe('logsCollection', () => {
             LogGroupName: '/aws/api-gateway/service-name-dev',
           },
         },
-        CloudWatchLogsSubscriptionFilterLambdaLogs: {
+        CWLSubFilterLambdaLogsUsEast1: {
           Type: 'AWS::Logs::SubscriptionFilter',
           Properties: {
             DestinationArn: 'arn:logdest',
@@ -104,7 +104,7 @@ describe('logsCollection', () => {
             },
           },
         },
-        CloudWatchLogsSubscriptionFilterApiGatewayLogs: {
+        CWLSubFilterApiGatewayLogsUsEast1: {
           Type: 'AWS::Logs::SubscriptionFilter',
           Properties: {
             DestinationArn: 'arn:logdest',


### PR DESCRIPTION
This will help us match incoming log messages to the source function at the Indexer.