### PR TITLE
fix: Always allow skip during `org` selection if `history` missing

### DIFF
--- a/lib/cli/interactive-setup/dashboard-set-org.js
+++ b/lib/cli/interactive-setup/dashboard-set-org.js
@@ -123,7 +123,7 @@ const steps = {
     if (!orgName) {
       orgName = await (async () => {
         // If user did not have an option to opt-out during login/register question, we want to offer that option here
-        if (orgNames.size === 1 && history.has('dashboardLogin')) {
+        if (orgNames.size === 1 && history && history.has('dashboardLogin')) {
           return orgNames.values().next().value;
         }
         return orgsChoice(inquirer, orgNames);

--- a/lib/cli/interactive-setup/dashboard-set-org.test.js
+++ b/lib/cli/interactive-setup/dashboard-set-org.test.js
@@ -396,6 +396,33 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(context.configuration.app).to.be.undefined;
     });
 
+    it('Should not automatically pre choose single available org if context history is not available', async () => {
+      configureInquirerStub(inquirer, {
+        list: { orgName: '_skip_' },
+      });
+      const { servicePath } = await fixtures.setup('aws-loggedin-service');
+      const context = {
+        serviceDir: servicePath,
+        configuration: {
+          service: 'some-aws-service',
+          provider: { name: 'aws', runtime: 'nodejs12.x' },
+        },
+        configurationFilename: 'serverless.yml',
+        options: {},
+        inquirer,
+      };
+      await overrideCwd(servicePath, async () => {
+        const stepData = await step.isApplicable(context);
+        if (!stepData) throw new Error('Step resolved as not applicable');
+        await step.run(context, stepData);
+      });
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
+      expect(serviceConfig.org).to.be.undefined;
+      expect(serviceConfig.app).to.be.undefined;
+      expect(context.configuration.org).to.be.undefined;
+      expect(context.configuration.app).to.be.undefined;
+    });
+
     it('Should setup monitoring with the only available org if login/register step was presented', async () => {
       const { servicePath } = await fixtures.setup('aws-loggedin-service');
       const context = {


### PR DESCRIPTION
Closes: https://github.com/serverless/serverless/issues/9497