### PR TITLE
Improve error reporting

### DIFF
--- a/lib/generateEvent.js
+++ b/lib/generateEvent.js
@@ -53,18 +53,18 @@ const eventDict = {
   'aws:websocket': (body) => ({ body }),
 };
 
-async function wrapEvent(eventType, body) {
+async function wrapEvent(eventType, body, ctx) {
   if (hasOwnProperty.call(eventDict, eventType)) {
     return createEvent(eventType, await eventDict[eventType](body));
   }
 
-  throw new Error('Invalid event specified.');
+  throw new ctx.sls.classes.Error('Invalid event specified', 'INVALID_EVENT_TYPE');
 }
 
 const generate = async function (ctx) {
   const { options } = ctx.sls.processedInput;
   const body = options.body === undefined ? '{}' : options.body;
-  const event = await wrapEvent(options.type, body);
+  const event = await wrapEvent(options.type, body, ctx);
   // eslint-disable-next-line no-console
   return console.log(JSON.stringify(event));
 };

--- a/lib/generateEvent.test.js
+++ b/lib/generateEvent.test.js
@@ -518,6 +518,7 @@ describe('generating events', () => {
   it('throws errors for invalid events', async () => {
     const ctx = {
       sls: {
+        classes: { Error },
         processedInput: {
           options: {
             type: 'none',

--- a/lib/logsCollection.js
+++ b/lib/logsCollection.js
@@ -80,10 +80,11 @@ module.exports = async (ctx) => {
 
     if (typeof logGroupName !== 'string') {
       if (!logGroupName || !logGroupName['Fn::Join']) {
-        throw new Error(
+        throw new ctx.sls.classes.Error(
           `Unable to resolve '${logGroupIndex}' log group name out of: ${inspect(
             logGroups[logGroupIndex].resource.Properties
-          )}`
+          )}`,
+          'CANNOT_RESOLVE_LOG_GROUP'
         );
       }
       if (logGroupName['Fn::Join']) {

--- a/lib/logsCollection.js
+++ b/lib/logsCollection.js
@@ -70,7 +70,7 @@ module.exports = async (ctx) => {
       );
       return;
     }
-    throw new Error(e.message);
+    throw e;
   }
 
   // For each log group, set up subscription

--- a/lib/logsCollection.test.js
+++ b/lib/logsCollection.test.js
@@ -127,6 +127,7 @@ describe('logsCollection', () => {
     const ctx = {
       sls: {
         cli: { log },
+        classes: { Error },
         service: {
           org: 'org',
           app: 'app',


### PR DESCRIPTION
Continuation of https://github.com/serverless/serverless/pull/9499

Ensure that user errors are thrown with `ServerlessError` constructor