### PR TITLE
feat: Always ask for `org` in CLI when invoked for existing service

### DIFF
--- a/lib/cli/interactive-setup/dashboard-set-org.js
+++ b/lib/cli/interactive-setup/dashboard-set-org.js
@@ -89,6 +89,12 @@ const appNameInput = async (inquirer, appNames) =>
 
 const steps = {
   resolveOrgNames: async (user) => {
+    if (process.env.SERVERLESS_ACCESS_KEY) {
+      const sdk = new ServerlessSDK({ accessKey: process.env.SERVERLESS_ACCESS_KEY });
+      const { orgName } = await sdk.accessKeys.get();
+      return new Set([orgName]);
+    }
+
     let orgs = new Set();
     if (!user.idToken) {
       // User registered over CLI hence idToken is not stored.
@@ -124,7 +130,7 @@ const steps = {
       orgName = await (async () => {
         // We only want to automatically select the single available org in situations where user explicitly
         // logged in/registered during the process and created new service, for existing services we want to always ask
-        // that question
+        // that question. It will also be always asked if `SERVERLESS_ACCESS_KEY` was provided
         if (
           orgNames.size === 1 &&
           history &&
@@ -189,7 +195,6 @@ module.exports = {
     ) {
       return false;
     }
-    if (process.env.SERVERLESS_ACCESS_KEY) return false;
     const sdk = new ServerlessSDK();
     const { supportedRegions, supportedRuntimes } = await sdk.metadata.get();
     if (!supportedRuntimes.includes(_.get(configuration.provider, 'runtime') || 'nodejs12.x')) {
@@ -200,13 +205,16 @@ module.exports = {
     ) {
       return false;
     }
+    const usesServerlessAccessKey = Boolean(process.env.SERVERLESS_ACCESS_KEY);
 
     let user = configUtils.getLoggedInUser();
-    if (!user) return false;
+    if (!user && !usesServerlessAccessKey) return false;
 
     const orgNames = await steps.resolveOrgNames(user);
     if (!orgNames.size) return false;
-    user = configUtils.getLoggedInUser(); // Refreshed, as new token might have been generated
+    if (!usesServerlessAccessKey) {
+      user = configUtils.getLoggedInUser(); // Refreshed, as new token might have been generated
+    }
 
     const orgName = options.org || configuration.org;
     const appName = options.app || configuration.app;

--- a/lib/cli/interactive-setup/dashboard-set-org.js
+++ b/lib/cli/interactive-setup/dashboard-set-org.js
@@ -122,8 +122,15 @@ const steps = {
     const { inquirer, history } = context;
     if (!orgName) {
       orgName = await (async () => {
-        // If user did not have an option to opt-out during login/register question, we want to offer that option here
-        if (orgNames.size === 1 && history && history.has('dashboardLogin')) {
+        // We only want to automatically select the single available org in situations where user explicitly
+        // logged in/registered during the process and created new service, for existing services we want to always ask
+        // that question
+        if (
+          orgNames.size === 1 &&
+          history &&
+          history.has('dashboardLogin') &&
+          history.has('service')
+        ) {
           return orgNames.values().next().value;
         }
         return orgsChoice(inquirer, orgNames);

--- a/lib/cli/interactive-setup/dashboard-set-org.test.js
+++ b/lib/cli/interactive-setup/dashboard-set-org.test.js
@@ -9,6 +9,7 @@ const yaml = require('yamljs');
 const resolveSync = require('ncjsm/resolve/sync');
 const overrideCwd = require('process-utils/override-cwd');
 const overrideStdoutWrite = require('process-utils/override-stdout-write');
+const overrideEnv = require('process-utils/override-env');
 const configureInquirerStub = require('@serverless/test/configure-inquirer-stub');
 const semver = require('semver');
 
@@ -87,6 +88,14 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
         this.organizations = {
           list: async () => {
             return mockOrganizationsList;
+          },
+        };
+
+        this.accessKeys = {
+          get: async () => {
+            return {
+              orgName: 'fromaccesskey',
+            };
           },
         };
       }
@@ -335,6 +344,79 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(stdoutData).to.include(
         'Your project has been setup with org: "testinteractivecli" and app: "other-app"'
       );
+    });
+
+    it('Should setup monitoring for chosen app and org based on access key', async () => {
+      configureInquirerStub(inquirer, {
+        list: { orgName: 'fromaccesskey', appName: 'other-app' },
+      });
+      const { servicePath } = await fixtures.setup('aws-loggedin-service');
+      const context = {
+        serviceDir: servicePath,
+        configuration: {
+          service: 'some-aws-service',
+          provider: { name: 'aws', runtime: 'nodejs12.x' },
+        },
+        configurationFilename: 'serverless.yml',
+        options: {},
+        inquirer,
+      };
+      let stdoutData = '';
+      await overrideEnv({ variables: { SERVERLESS_ACCESS_KEY: 'validkey' } }, async () => {
+        await overrideCwd(servicePath, async () => {
+          await overrideStdoutWrite(
+            (data) => (stdoutData += data),
+            async () => {
+              const stepData = await step.isApplicable(context);
+              if (!stepData) throw new Error('Step resolved as not applicable');
+              await step.run(context, stepData);
+            }
+          );
+        });
+      });
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
+      expect(serviceConfig.org).to.equal('fromaccesskey');
+      expect(serviceConfig.app).to.equal('other-app');
+      expect(context.configuration.org).to.equal('fromaccesskey');
+      expect(context.configuration.app).to.equal('other-app');
+      expect(stdoutData).to.include(
+        'Your project has been setup with org: "fromaccesskey" and app: "other-app"'
+      );
+    });
+
+    it('Should allow to skip monitoring when org is resolved from access key', async () => {
+      configureInquirerStub(inquirer, {
+        list: { orgName: '_skip_' },
+      });
+      const { servicePath } = await fixtures.setup('aws-loggedin-service');
+      const context = {
+        serviceDir: servicePath,
+        configuration: {
+          service: 'some-aws-service',
+          provider: { name: 'aws', runtime: 'nodejs12.x' },
+        },
+        configurationFilename: 'serverless.yml',
+        options: {},
+        inquirer,
+      };
+      let stdoutData = '';
+      await overrideEnv({ variables: { SERVERLESS_ACCESS_KEY: 'validkey' } }, async () => {
+        await overrideCwd(servicePath, async () => {
+          await overrideStdoutWrite(
+            (data) => (stdoutData += data),
+            async () => {
+              const stepData = await step.isApplicable(context);
+              if (!stepData) throw new Error('Step resolved as not applicable');
+              await step.run(context, stepData);
+            }
+          );
+        });
+      });
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
+      expect(serviceConfig.org).to.be.undefined;
+      expect(serviceConfig.app).to.be.undefined;
+      expect(context.configuration.org).to.be.undefined;
+      expect(context.configuration.app).to.be.undefined;
     });
 
     it('Should allow to skip setting monitoring when selecting org', async () => {

--- a/lib/cli/interactive-setup/dashboard-set-org.test.js
+++ b/lib/cli/interactive-setup/dashboard-set-org.test.js
@@ -433,7 +433,10 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(context.configuration.app).to.be.undefined;
     });
 
-    it('Should setup monitoring with the only available org if login/register step was presented', async () => {
+    it('Should not automatically pre choose single available org if login/register step was presented but service step was not', async () => {
+      configureInquirerStub(inquirer, {
+        list: { orgName: '_skip_' },
+      });
       const { servicePath } = await fixtures.setup('aws-loggedin-service');
       const context = {
         serviceDir: servicePath,
@@ -445,6 +448,34 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
         options: {},
         inquirer,
         history: new Map([['dashboardLogin', []]]),
+      };
+      await overrideCwd(servicePath, async () => {
+        const stepData = await step.isApplicable(context);
+        if (!stepData) throw new Error('Step resolved as not applicable');
+        await step.run(context, stepData);
+      });
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
+      expect(serviceConfig.org).to.be.undefined;
+      expect(serviceConfig.app).to.be.undefined;
+      expect(context.configuration.org).to.be.undefined;
+      expect(context.configuration.app).to.be.undefined;
+    });
+
+    it('Should setup monitoring with the only available org if login/register and service steps were presented', async () => {
+      const { servicePath } = await fixtures.setup('aws-loggedin-service');
+      const context = {
+        serviceDir: servicePath,
+        configuration: {
+          service: 'some-aws-service',
+          provider: { name: 'aws', runtime: 'nodejs12.x' },
+        },
+        configurationFilename: 'serverless.yml',
+        options: {},
+        inquirer,
+        history: new Map([
+          ['dashboardLogin', []],
+          ['service', []],
+        ]),
       };
       let stdoutData = '';
       await overrideCwd(servicePath, async () => {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "serverless/dashboard-plugin",
   "dependencies": {
     "@serverless/event-mocks": "^1.1.1",
-    "@serverless/platform-client": "^4.2.2",
+    "@serverless/platform-client": "^4.2.3",
     "@serverless/utils": "^5.2.0",
     "chalk": "^4.1.1",
     "child-process-ext": "^2.1.1",


### PR DESCRIPTION
1. Ensures to not default to the only `org` if invoked in existing service context
2. Support `SERVERLESS_ACCESS_KEY`-based org resolution 