### PR TITLE
Do not rely on `variablesSyntax`

### DIFF
--- a/lib/deployProfile.js
+++ b/lib/deployProfile.js
@@ -30,11 +30,12 @@ module.exports.configureDeployProfile = async (ctx) => {
     { name: 'stage', value: stage },
     { name: 'region', value: region },
   ]) {
-    if (argument.value.match(ctx.sls.service.provider.variableSyntax)) {
+    if (argument.value.includes('${')) {
       parameterizedArgs.push(argument);
     }
   }
   if (parameterizedArgs.length) {
+    // TODO: Remove once Framework is at v3
     const names = parameterizedArgs.map((arg) => arg.name).join(', ');
     ctx.sls._logDeprecation(
       'PARAMETERIZED_ARGUMENT',

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -246,10 +246,8 @@ class ServerlessEnterprisePlugin {
     if (missing.length > 0) {
       this.sfeEnabledHooks = {};
     } else {
-      if (
-        sls.service.app.match(new RegExp(sls.service.provider.variableSyntax)) ||
-        sls.service.org.match(new RegExp(sls.service.provider.variableSyntax))
-      ) {
+      // TODO: Remove this check once Framework is at V3
+      if (sls.service.app.includes('${') || sls.service.org.includes('${')) {
         throw new this.sls.classes.Error(
           '"app" and "org" in your serverless config can not use the variable system'
         );


### PR DESCRIPTION
Follow up to: https://github.com/serverless/serverless/commit/582d150ceb01d3f597a30fcc82201ffa325c4617

Default for this property is no longer exposed in internal configuration, also with Framework v3, this property will no longer be in use