### PR TITLE
Add `getDashboardInteractUrl` util

### DIFF
--- a/lib/cli/interactive-setup/dashboard-set-org.js
+++ b/lib/cli/interactive-setup/dashboard-set-org.js
@@ -178,9 +178,9 @@ const steps = {
       }
     }
     process.stdout.write(
-      `\n${chalk.green(
-        `Your project has been setup with org: "${orgName}" and app: "${appName}"`
-      )}\n`
+      `\n${chalk.green('Your project has been setup with org: ')}${chalk.white.bold(
+        orgName
+      )}${chalk.green(' and app: ')}${chalk.white.bold(appName)}\n`
     );
     await writeOrgAndApp(orgName, appName, context);
     return;

--- a/lib/cli/interactive-setup/dashboard-set-org.test.js
+++ b/lib/cli/interactive-setup/dashboard-set-org.test.js
@@ -12,6 +12,7 @@ const overrideStdoutWrite = require('process-utils/override-stdout-write');
 const overrideEnv = require('process-utils/override-env');
 const configureInquirerStub = require('@serverless/test/configure-inquirer-stub');
 const semver = require('semver');
+const stripAnsi = require('strip-ansi');
 
 const setupServerless = require('../../../test/setupServerless');
 const fixtures = require('../../../test/fixtures');
@@ -341,8 +342,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('other-app');
       expect(context.configuration.org).to.equal('testinteractivecli');
       expect(context.configuration.app).to.equal('other-app');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "testinteractivecli" and app: "other-app"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: testinteractivecli and app: other-app'
       );
     });
 
@@ -379,8 +380,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('other-app');
       expect(context.configuration.org).to.equal('fromaccesskey');
       expect(context.configuration.app).to.equal('other-app');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "fromaccesskey" and app: "other-app"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: fromaccesskey and app: other-app'
       );
     });
 
@@ -575,8 +576,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('some-aws-service');
       expect(context.configuration.org).to.equal('orgwithoutapps');
       expect(context.configuration.app).to.equal('some-aws-service');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "orgwithoutapps" and app: "some-aws-service"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: orgwithoutapps and app: some-aws-service'
       );
     });
   });
@@ -610,8 +611,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('other-app');
       expect(context.configuration.org).to.equal('testinteractivecli');
       expect(context.configuration.app).to.equal('other-app');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "testinteractivecli" and app: "other-app"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: testinteractivecli and app: other-app'
       );
     });
 
@@ -649,8 +650,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('app-from-flag');
       expect(context.configuration.org).to.equal('otherorg');
       expect(context.configuration.app).to.equal('app-from-flag');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "otherorg" and app: "app-from-flag"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: otherorg and app: app-from-flag'
       );
     });
 
@@ -714,8 +715,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('other-app');
       expect(context.configuration.org).to.equal('testinteractivecli');
       expect(context.configuration.app).to.equal('other-app');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "testinteractivecli" and app: "other-app"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: testinteractivecli and app: other-app'
       );
     });
 
@@ -754,8 +755,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('other-app');
       expect(context.configuration.org).to.equal('otherorg');
       expect(context.configuration.app).to.equal('other-app');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "otherorg" and app: "other-app"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: otherorg and app: other-app'
       );
     });
 
@@ -793,8 +794,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('other-app');
       expect(context.configuration.org).to.equal('testinteractivecli');
       expect(context.configuration.app).to.equal('other-app');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "testinteractivecli" and app: "other-app"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: testinteractivecli and app: other-app'
       );
     });
 
@@ -829,8 +830,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('other-app');
       expect(context.configuration.org).to.equal('testinteractivecli');
       expect(context.configuration.app).to.equal('other-app');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "testinteractivecli" and app: "other-app"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: testinteractivecli and app: other-app'
       );
     });
 
@@ -866,8 +867,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('frominput');
       expect(context.configuration.org).to.equal('testinteractivecli');
       expect(context.configuration.app).to.equal('frominput');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "testinteractivecli" and app: "frominput"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: testinteractivecli and app: frominput'
       );
     });
   });
@@ -907,8 +908,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('other-app');
       expect(context.configuration.org).to.equal('testinteractivecli');
       expect(context.configuration.app).to.equal('other-app');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "testinteractivecli" and app: "other-app"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: testinteractivecli and app: other-app'
       );
     });
   });
@@ -946,8 +947,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('other-app');
       expect(context.configuration.org).to.equal('testinteractivecli');
       expect(context.configuration.app).to.equal('other-app');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "testinteractivecli" and app: "other-app"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: testinteractivecli and app: other-app'
       );
     });
   });
@@ -982,8 +983,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('app-from-flag');
       expect(context.configuration.org).to.equal('testinteractivecli');
       expect(context.configuration.app).to.equal('app-from-flag');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "testinteractivecli" and app: "app-from-flag"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: testinteractivecli and app: app-from-flag'
       );
     });
 
@@ -1016,8 +1017,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('someservice');
       expect(context.configuration.org).to.equal('orgwithoutapps');
       expect(context.configuration.app).to.equal('someservice');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "orgwithoutapps" and app: "someservice"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: orgwithoutapps and app: someservice'
       );
     });
 
@@ -1053,8 +1054,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('other-app');
       expect(context.configuration.org).to.equal('testinteractivecli');
       expect(context.configuration.app).to.equal('other-app');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "testinteractivecli" and app: "other-app"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: testinteractivecli and app: other-app'
       );
     });
   });
@@ -1093,8 +1094,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('not-created-app');
       expect(context.configuration.org).to.equal('testinteractivecli');
       expect(context.configuration.app).to.equal('not-created-app');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "testinteractivecli" and app: "not-created-app"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: testinteractivecli and app: not-created-app'
       );
     });
 
@@ -1131,8 +1132,8 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
       expect(serviceConfig.app).to.equal('other-app');
       expect(context.configuration.org).to.equal('testinteractivecli');
       expect(context.configuration.app).to.equal('other-app');
-      expect(stdoutData).to.include(
-        'Your project has been setup with org: "testinteractivecli" and app: "other-app"'
+      expect(stripAnsi(stdoutData)).to.include(
+        'Your project has been setup with org: testinteractivecli and app: other-app'
       );
     });
   });

--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -5,10 +5,17 @@ const dashboardUrl =
     ? 'https://app.serverless-dev.com/'
     : 'https://app.serverless.com/';
 
-module.exports.getDashboardUrl = (ctx) => {
+const getDashboardUrl = (ctx) => {
   if (!ctx.sls.enterpriseEnabled) return dashboardUrl;
   const { service } = ctx.sls;
   return `${dashboardUrl}${service.org}/apps/${service.app}/${
     service.service
   }/${ctx.provider.getStage()}/${ctx.provider.getRegion()}`;
+};
+
+module.exports.getDashboardUrl = getDashboardUrl;
+
+module.exports.getDashboardInteractUrl = (ctx) => {
+  if (!ctx.sls.enterpriseEnabled) return null;
+  return `${getDashboardUrl(ctx)}/interact`;
 };


### PR DESCRIPTION
Adds `getDashboardInteractUrl` util + improves formatting of success message in `dashboard-set-org` step of Onboarding CLI 

Addresses: https://github.com/serverless/serverless/issues/9367

Related to: https://github.com/serverless/serverless/pull/9536