### PR TITLE
refactor: Use `confirm` prompt in `login/register` question

### DIFF
--- a/lib/cli/interactive-setup/dashboard-login.js
+++ b/lib/cli/interactive-setup/dashboard-login.js
@@ -9,16 +9,15 @@ const loginOrRegisterQuestion = async (inquirer) =>
   (
     await inquirer.prompt({
       message: 'Do you want to login/register to Serverless Dashboard?',
-      type: 'list',
+      type: 'confirm',
       name: 'shouldLoginOrRegister',
-      choices: ['Yes', 'No'],
     })
   ).shouldLoginOrRegister;
 
 const steps = {
   loginOrRegister: async (context) => {
     const result = await loginOrRegisterQuestion(context.inquirer);
-    if (result === 'Yes') {
+    if (result) {
       await login({ isInteractive: true });
     }
   },

--- a/lib/cli/interactive-setup/dashboard-login.test.js
+++ b/lib/cli/interactive-setup/dashboard-login.test.js
@@ -108,7 +108,7 @@ describe('lib/cli/interactive-setup/dashboard-login.test.js', function () {
 
   it('Should login when user decides to login/register', async () => {
     configureInquirerStub(inquirer, {
-      list: { shouldLoginOrRegister: 'Yes' },
+      confirm: { shouldLoginOrRegister: true },
     });
     const loginStep = proxyquire('./dashboard-login', {
       '../../login': loginStub,
@@ -128,7 +128,7 @@ describe('lib/cli/interactive-setup/dashboard-login.test.js', function () {
 
   it('Should not login when user decides not to login/register', async () => {
     configureInquirerStub(inquirer, {
-      list: { shouldLoginOrRegister: 'No' },
+      confirm: { shouldLoginOrRegister: false },
     });
     const loginStep = proxyquire('./dashboard-login', {
       '../../login': loginStub,


### PR DESCRIPTION
In order to be consistent with the way we ask `Yes/No` questions, use `confirm` prompt for `login/register` question