### PR TITLE
refactor: Fix logging output for `login/register` interactive step

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -4,16 +4,15 @@ const open = require('open');
 const { ServerlessSDK } = require('@serverless/platform-client');
 const configUtils = require('@serverless/utils/config');
 const log = require('@serverless/utils/log');
+const chalk = require('chalk');
 
 module.exports = async function ({ isInteractive } = {}) {
-  const logOptions = {};
-  // We want to remove prefix and change color from yellow in interactive flow only
+  // TODO: Logging should be unified after implementing: https://github.com/serverless/serverless/issues/1720
   if (isInteractive) {
-    logOptions.entity = '';
-    logOptions.color = 'white';
+    process.stdout.write('\nLogging you in via your default browser...\n');
+  } else {
+    log('Logging you in via your default browser...');
   }
-
-  log('Logging you in via your default browser...', logOptions);
 
   const sdk = new ServerlessSDK();
 
@@ -24,7 +23,13 @@ module.exports = async function ({ isInteractive } = {}) {
   const { loginUrl, loginData: loginDataDeferred } = await sdk.login();
 
   open(loginUrl);
-  log(`If your browser does not open automatically, please open the URL: ${loginUrl}`, logOptions);
+  if (isInteractive) {
+    process.stdout.write(
+      `\nIf your browser does not open automatically, please open the URL: ${loginUrl}\n`
+    );
+  } else {
+    log(`If your browser does not open automatically, please open the URL: ${loginUrl}`);
+  }
 
   const loginData = await loginDataDeferred;
 
@@ -53,5 +58,9 @@ module.exports = async function ({ isInteractive } = {}) {
   // save the login data in the rc file
   configUtils.set(loginDataToSaveInConfig);
 
-  log('You sucessfully logged in to Serverless.', logOptions);
+  if (isInteractive) {
+    process.stdout.write(chalk.green('\nYou sucessfully logged in to Serverless\n'));
+  } else {
+    log('You sucessfully logged in to Serverless.');
+  }
 };


### PR DESCRIPTION
Adjust logs emitted during interactive flow's login step to consistent with all other outputs

Addresses: https://github.com/serverless/serverless/issues/9367