### PR TITLE
Fix build warning with externals

### DIFF
--- a/sdk-js/webpack.config.js
+++ b/sdk-js/webpack.config.js
@@ -13,4 +13,10 @@ module.exports = {
     filename: 'index.js',
     libraryTarget: 'umd',
   },
+  externals: {
+    // Dynamic imports that are never used (gets rid of bundle warning).
+    'bufferutil': 'bufferutil',
+    'original-fs': 'original-fs',
+    'utf-8-validate': 'utf-8-validate',
+  },
 };

--- a/sdk-js/webpack.config.js
+++ b/sdk-js/webpack.config.js
@@ -14,9 +14,10 @@ module.exports = {
     libraryTarget: 'umd',
   },
   externals: {
-    // Dynamic imports that are never used (gets rid of bundle warning).
+    // Module (if required) is provided by Electron
+    'original-fs': 'original-fs', 
+    // Optional WS modules - https://github.com/websockets/ws#opt-in-for-performance
     'bufferutil': 'bufferutil',
-    'original-fs': 'original-fs',
     'utf-8-validate': 'utf-8-validate',
   },
 };

--- a/sdk-js/webpack.config.js
+++ b/sdk-js/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
   },
   externals: {
     // Module (if required) is provided by Electron
-    'original-fs': 'original-fs', 
+    'original-fs': 'original-fs',
     // Optional WS modules - https://github.com/websockets/ws#opt-in-for-performance
     'bufferutil': 'bufferutil',
     'utf-8-validate': 'utf-8-validate',


### PR DESCRIPTION
# About

I was seeing warnings (below) due to missing dependencies at bundle time.

<details>

<summary>Warning message</summary>

```
WARNING in ./node_modules/ws/lib/buffer-util.js
Module not found: Error: Can't resolve 'bufferutil' in '/home/andy/dev/dashboard-plugin/sdk-js/node_modules/ws/lib'
 @ ./node_modules/ws/lib/buffer-util.js
 @ ./node_modules/ws/lib/websocket.js
 @ ./node_modules/ws/index.js
 @ ./node_modules/isomorphic-ws/node.js
 @ ./node_modules/@serverless/platform-client/src/index.js
 @ ./src/index.js
 @ multi ./src/index.js

WARNING in ./node_modules/adm-zip/util/fileSystem.js
Module not found: Error: Can't resolve 'original-fs' in '/home/andy/dev/dashboard-plugin/sdk-js/node_modules/adm-zip/util'
 @ ./node_modules/adm-zip/util/fileSystem.js
 @ ./node_modules/adm-zip/util/index.js
 @ ./node_modules/adm-zip/adm-zip.js
 @ ./node_modules/@serverless/platform-client/src/utils.js
 @ ./node_modules/@serverless/platform-client/src/index.js
 @ ./src/index.js
 @ multi ./src/index.js

WARNING in ./node_modules/ws/lib/validation.js
Module not found: Error: Can't resolve 'utf-8-validate' in '/home/andy/dev/dashboard-plugin/sdk-js/node_modules/ws/lib'
 @ ./node_modules/ws/lib/validation.js
 @ ./node_modules/ws/lib/receiver.js
 @ ./node_modules/ws/index.js
 @ ./node_modules/isomorphic-ws/node.js
 @ ./node_modules/@serverless/platform-client/src/index.js
 @ ./src/index.js
 @ multi ./src/index.js
```

</details>

I'm guessing the missing deps are dynamic imports that are never used (for our purposes) at runtime.

If for some reason they are used at runtime, it might make more sense to instead add these dependencies to be included in the bundle.