### PR TITLE
fix: Recognize if not in service and when logged in in onboarding

### DIFF
--- a/lib/cli/interactive-setup/dashboard-login.js
+++ b/lib/cli/interactive-setup/dashboard-login.js
@@ -27,7 +27,13 @@ const steps = {
 
 module.exports = {
   async isApplicable(context) {
-    const { configuration, options } = context;
+    const { configuration, options, serviceDir } = context;
+
+    if (!serviceDir) {
+      context.inapplicabilityReasonCode = 'NOT_IN_SERVICE_DIRECTORY';
+      return false;
+    }
+
     if (
       _.get(configuration, 'provider') !== 'aws' &&
       _.get(configuration, 'provider.name') !== 'aws'
@@ -35,10 +41,12 @@ module.exports = {
       context.inapplicabilityReasonCode = 'NON_AWS_PROVIDER';
       return false;
     }
+
     if (process.env.SERVERLESS_ACCESS_KEY) {
       context.inapplicabilityReasonCode = 'SERVERLESS_ACCESS_KEY_PROVIDED';
       return false;
     }
+
     const sdk = new ServerlessSDK();
     const { supportedRegions, supportedRuntimes } = await sdk.metadata.get();
     if (!supportedRuntimes.includes(_.get(configuration.provider, 'runtime') || 'nodejs12.x')) {

--- a/lib/cli/interactive-setup/dashboard-login.test.js
+++ b/lib/cli/interactive-setup/dashboard-login.test.js
@@ -69,7 +69,7 @@ describe('lib/cli/interactive-setup/dashboard-login.test.js', function () {
   it('Should be ineffective, when not at service path', async () => {
     const context = {};
     expect(await step.isApplicable(context)).to.be.false;
-    expect(context.inapplicabilityReasonCode).to.equal('NON_AWS_PROVIDER');
+    expect(context.inapplicabilityReasonCode).to.equal('NOT_IN_SERVICE_DIRECTORY');
   });
 
   it('Should be ineffective, when not at AWS service path', async () => {

--- a/lib/cli/interactive-setup/dashboard-set-org.js
+++ b/lib/cli/interactive-setup/dashboard-set-org.js
@@ -205,7 +205,12 @@ const steps = {
 
 module.exports = {
   async isApplicable(context) {
-    const { configuration, options } = context;
+    const { configuration, options, serviceDir } = context;
+    if (!serviceDir) {
+      context.inapplicabilityReasonCode = 'NOT_IN_SERVICE_DIRECTORY';
+      return false;
+    }
+
     if (
       _.get(configuration, 'provider') !== 'aws' &&
       _.get(configuration, 'provider.name') !== 'aws'

--- a/lib/cli/interactive-setup/dashboard-set-org.test.js
+++ b/lib/cli/interactive-setup/dashboard-set-org.test.js
@@ -131,7 +131,7 @@ describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
   it('Should be ineffective, when not at service path', async () => {
     const context = {};
     expect(await step.isApplicable(context)).to.be.false;
-    expect(context.inapplicabilityReasonCode).to.equal('NON_AWS_PROVIDER');
+    expect(context.inapplicabilityReasonCode).to.equal('NOT_IN_SERVICE_DIRECTORY');
   });
 
   it('Should be ineffective, when not at AWS service path', async () => {


### PR DESCRIPTION
Reported internally, ensure to always first check if user is logged in for login step and properly recognize if not in service directory