### PR TITLE
Ensure `dashboard` command is handled properly

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -1,21 +1,86 @@
 'use strict';
 
+const chalk = require('chalk');
+const open = require('open');
+const log = require('@serverless/utils/log');
+const { getPlatformClientWithAccessKey } = require('./clientUtils');
+const isAuthenticated = require('./isAuthenticated');
+
 const dashboardUrl =
   process.env.SERVERLESS_PLATFORM_STAGE === 'dev'
     ? 'https://app.serverless-dev.com/'
     : 'https://app.serverless.com/';
 
-const getDashboardUrl = (ctx) => {
-  if (!ctx.sls.enterpriseEnabled) return dashboardUrl;
+const getServiceSpecificDashboardUrl = (ctx) => {
   const { service } = ctx.sls;
   return `${dashboardUrl}${service.org}/apps/${service.app}/${
     service.service
   }/${ctx.provider.getStage()}/${ctx.provider.getRegion()}`;
 };
 
-module.exports.getDashboardUrl = getDashboardUrl;
+// Left as-is as it is a part of public API used e.g. in Framework directly
+const getDashboardUrl = (ctx) => {
+  if (!ctx.sls.enterpriseEnabled) return dashboardUrl;
+  return getServiceSpecificDashboardUrl(ctx);
+};
 
-module.exports.getDashboardInteractUrl = (ctx) => {
+const getDashboardInteractUrl = (ctx) => {
   if (!ctx.sls.enterpriseEnabled) return null;
   return `${getDashboardUrl(ctx)}/interact`;
+};
+
+const hasExistingDeployments = async (service, provider) => {
+  try {
+    const platformSdk = await getPlatformClientWithAccessKey(service.org);
+    const deploymentsListResult = await platformSdk.frameworkDeployments.list({
+      orgName: service.org,
+      appName: service.app,
+      regionName: provider.getRegion(),
+      stageName: provider.getStage(),
+      serviceName: service.service,
+    });
+    if (deploymentsListResult.items.length) {
+      return true;
+    }
+  } catch (e) {
+    if (process.env.SLS_DEBUG) {
+      log(`Encountered error when trying to check existing service deployments: ${e}`);
+    }
+  }
+
+  return false;
+};
+
+const dashboardHandler = async (ctx) => {
+  const { service } = ctx.sls;
+  const isServiceIntegratedWithDashboard = Boolean(service.org);
+
+  if (!isServiceIntegratedWithDashboard) {
+    process.stdout.write(
+      `This service does not use the Serverless Dashboard. Run ${chalk.bold(
+        'serverless'
+      )} to get started.\n`
+    );
+    return;
+  }
+
+  if (!isAuthenticated()) {
+    process.stdout.write(
+      `Could not find logged in user. Run ${chalk.bold('serverless login')} and try again.\n`
+    );
+    return;
+  }
+
+  if (await hasExistingDeployments(service, ctx.provider)) {
+    open(await getServiceSpecificDashboardUrl(ctx));
+    return;
+  }
+
+  open(dashboardUrl);
+};
+
+module.exports = {
+  dashboardHandler,
+  getDashboardUrl,
+  getDashboardInteractUrl,
 };

--- a/lib/dashboard.test.js
+++ b/lib/dashboard.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const chai = require('chai');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const overrideStdoutWrite = require('process-utils/override-stdout-write');
+const stripAnsi = require('strip-ansi');
+
+chai.use(require('sinon-chai'));
+
+let deploymentsListResponse;
+let isAuthenticated;
+const openStub = sinon.stub();
+
+const { expect } = chai;
+
+const ServerlessSDKMock = class ServerlessSDK {
+  constructor() {
+    this.frameworkDeployments = {
+      list: () => deploymentsListResponse,
+    };
+  }
+};
+
+const { dashboardHandler } = proxyquire('./dashboard', {
+  './clientUtils': {
+    getPlatformClientWithAccessKey: async () => new ServerlessSDKMock(),
+  },
+  './isAuthenticated': () => isAuthenticated,
+  'open': openStub,
+});
+
+const commonCtx = {
+  provider: { getStage: () => 'dev', getRegion: () => 'us-east-1' },
+  sls: {
+    service: {
+      service: 'service',
+      org: 'org',
+      app: 'app',
+    },
+  },
+};
+
+describe('dashboard', () => {
+  beforeEach(() => {
+    openStub.resetHistory();
+  });
+
+  describe('dashboardHandler', () => {
+    it('prints correct message when service is not integrated with dashboard', async () => {
+      isAuthenticated = true;
+      const ctx = {
+        ...commonCtx,
+        sls: {
+          service: {
+            service: 'service',
+          },
+        },
+      };
+
+      let stdoutData = '';
+      await overrideStdoutWrite(
+        (data) => (stdoutData += data),
+        async () => {
+          await dashboardHandler(ctx);
+        }
+      );
+      expect(stripAnsi(stdoutData)).to.include(
+        'This service does not use the Serverless Dashboard. Run serverless to get started.'
+      );
+    });
+
+    it('prints correct message if user is not authenticated', async () => {
+      isAuthenticated = false;
+
+      let stdoutData = '';
+      await overrideStdoutWrite(
+        (data) => (stdoutData += data),
+        async () => {
+          await dashboardHandler(commonCtx);
+        }
+      );
+      expect(stripAnsi(stdoutData)).to.include(
+        'Could not find logged in user. Run serverless login and try again'
+      );
+    });
+
+    it('opens correct link when service has no previous deployments', async () => {
+      isAuthenticated = true;
+      deploymentsListResponse = { items: [] };
+
+      await dashboardHandler(commonCtx);
+      expect(openStub).to.have.been.calledWith('https://app.serverless.com/');
+    });
+
+    it('opens correct link when service has previous deployments', async () => {
+      isAuthenticated = true;
+      deploymentsListResponse = { items: [{}] };
+
+      await dashboardHandler(commonCtx);
+      expect(openStub).to.have.been.calledWith(
+        'https://app.serverless.com/org/apps/app/service/dev/us-east-1'
+      );
+    });
+  });
+});

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -3,7 +3,6 @@
 const chalk = require('chalk');
 const _ = require('lodash');
 const { ServerlessSDK } = require('@serverless/platform-client');
-const open = require('open');
 const errorHandler = require('./errorHandler');
 const logsCollection = require('./logsCollection');
 const login = require('./login');
@@ -19,7 +18,7 @@ const variables = require('./variables');
 const { generate } = require('./generateEvent');
 const { configureDeployProfile } = require('./deployProfile');
 const { test } = require('./test');
-const { getDashboardUrl } = require('./dashboard');
+const { getDashboardUrl, dashboardHandler } = require('./dashboard');
 const setApiGatewayAccessLogFormat = require('./setApiGatewayAccessLogFormat');
 const paramCommand = require('./paramCommand');
 const outputCommand = require('./outputCommand');
@@ -362,7 +361,7 @@ class ServerlessEnterprisePlugin {
           );
           break;
         case 'dashboard:dashboard':
-          open(getDashboardUrl(this));
+          await dashboardHandler(this);
           break;
         case 'before:logs:logs':
           break;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "serverless/dashboard-plugin",
   "dependencies": {
     "@serverless/event-mocks": "^1.1.1",
-    "@serverless/platform-client": "^4.2.3",
+    "@serverless/platform-client": "^4.3.0",
     "@serverless/utils": "^5.3.0",
     "chalk": "^4.1.1",
     "child-process-ext": "^2.1.1",
@@ -48,6 +48,7 @@
     "process-utils": "^4.0.0",
     "proxyquire": "^2.1.3",
     "sinon": "^10.0.0",
+    "sinon-chai": "^3.7.0",
     "standard-version": "^9.3.0",
     "strip-ansi": "^6.0.0",
     "tar": "^6.1.0",


### PR DESCRIPTION
Reported internally, this change aims to address the issue of `serverless dashboard` command always redirecting to Dashboard's landing page.

Now it should:
1. Print out message when run outside of service context
2. Print message if user not logged in
3. Print message if service does not use dashboard
4. Properly redirect based on the fact if there were previous deployments or not