### PR TITLE
Use internal `serviceOutputs` handler

### DIFF
--- a/integration-testing/outputs.test.js
+++ b/integration-testing/outputs.test.js
@@ -12,9 +12,7 @@ let serviceTmpDir;
 let teardown1;
 let teardown2;
 
-describe('integration: outputs', function () {
-  this.timeout(1000 * 60 * 5);
-
+describe('integration: outputs', () => {
   before(async () => {
     [
       { sls: sls1, serviceName, teardown: teardown1 },

--- a/integration-testing/params.test.js
+++ b/integration-testing/params.test.js
@@ -6,9 +6,7 @@ const setup = require('./setup');
 
 let sls;
 
-describe('integration: params', function () {
-  this.timeout(1000 * 60 * 3);
-
+describe('integration: params', () => {
   before(async () => ({ sls } = await setup('service2')));
 
   it('print contains the params in the deploy profile', async () => {

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -16,9 +16,7 @@ let teardown;
 let serviceName;
 const org = process.env.SERVERLESS_PLATFORM_TEST_ORG || 'integration';
 
-describe('integration: wrapper', function () {
-  this.timeout(1000 * 60 * 5);
-
+describe('integration: wrapper', () => {
   let lambdaService;
   let cloudwatchLogsService;
 

--- a/lib/cli/interactive-setup/dashboard-login.test.js
+++ b/lib/cli/interactive-setup/dashboard-login.test.js
@@ -48,9 +48,7 @@ const step = proxyquire('./dashboard-login', {
   },
 });
 
-describe('lib/cli/interactive-setup/dashboard-login.test.js', function () {
-  this.timeout(1000 * 60 * 3);
-
+describe('lib/cli/interactive-setup/dashboard-login.test.js', () => {
   let inquirer;
   const loginStub = sinon.stub().resolves();
 

--- a/lib/cli/interactive-setup/dashboard-set-org.test.js
+++ b/lib/cli/interactive-setup/dashboard-set-org.test.js
@@ -26,9 +26,7 @@ chai.use(require('chai-as-promised'));
 
 const fixturesPath = join(__dirname, '../../../test/fixtures');
 
-describe('lib/cli/interactive-setup/dashboard-set-org.test.js', function () {
-  this.timeout(1000 * 60 * 3);
-
+describe('lib/cli/interactive-setup/dashboard-set-org.test.js', () => {
   let step;
   let serverlessPath;
   let serverlessVersion;

--- a/lib/outputCommand.test.js
+++ b/lib/outputCommand.test.js
@@ -65,9 +65,7 @@ const modulesCacheStub = {
   },
 };
 
-describe('outputCommand', function () {
-  this.timeout(1000 * 60 * 3);
-
+describe('outputCommand', () => {
   afterEach(() => sinon.resetHistory());
 
   describe('list', () => {

--- a/lib/paramCommand.test.js
+++ b/lib/paramCommand.test.js
@@ -46,9 +46,7 @@ const modulesCacheStub = {
   },
 };
 
-describe('paramCommand', function () {
-  this.timeout(1000 * 60 * 3);
-
+describe('paramCommand', () => {
   afterEach(() => sinon.resetHistory());
 
   describe('list', () => {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -344,8 +344,8 @@ class ServerlessEnterprisePlugin {
           break;
         case 'before:aws:info:validate':
           // TODO: Remove conditional with next major
-          if (this.sls.addServiceOutputSection) {
-            this.sls.addServiceOutputSection('dashboard', getDashboardUrl(this));
+          if (this.sls.serviceOutputs) {
+            this.sls.serviceOutputs.set('dashboard', getDashboardUrl(this));
           }
           break;
         case 'after:aws:deploy:finalize:cleanup':

--- a/lib/providersIntegration.test.js
+++ b/lib/providersIntegration.test.js
@@ -55,9 +55,7 @@ const modulesCacheStub = {
   },
 };
 
-describe('deployProfile', function () {
-  this.timeout(1000 * 60 * 3);
-
+describe('deployProfile', () => {
   it('Should override with credentials', async () => {
     const { serverless } = await runServerless({
       fixture: 'aws-monitored-service',

--- a/lib/studio.test.js
+++ b/lib/studio.test.js
@@ -14,9 +14,7 @@ const modulesCacheStub = {
 
 const userNodeVersion = Number(process.version.split('.')[0].slice(1));
 
-describe('studio', function () {
-  this.timeout(1000 * 60 * 3);
-
+describe('studio', () => {
   it('Should crash when not logged in', async () => {
     if (userNodeVersion < 8) {
       return;

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -515,9 +515,7 @@ except Exception as error:
   });
 });
 
-describe('wrap #2', function () {
-  this.timeout(1000 * 60 * 3);
-
+describe('wrap #2', () => {
   it('Should not log meta log on local invocation', async () => {
     const { stdoutData } = await runServerless({
       fixture: 'function',

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
       "@serverless/test/setup/mock-cwd",
       "@serverless/test/setup/restore-env"
     ],
-    "timeout": 120000
+    "timeout": 360000
   },
   "nyc": {
     "all": true,


### PR DESCRIPTION
Follow up to https://github.com/serverless/serverless/pull/10184

This change is also safe for already deployed version