### PR TITLE
CLI: Refactor `cli.log` based logs into modern logs

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -4,7 +4,8 @@ const chalk = require('chalk');
 const open = require('open');
 const { getPlatformClientWithAccessKey } = require('./clientUtils');
 const isAuthenticated = require('./isAuthenticated');
-const { legacy, log } = require('@serverless/utils/log');
+const { legacy } = require('@serverless/utils/log');
+const log = require('./log');
 
 const dashboardUrl =
   process.env.SERVERLESS_PLATFORM_STAGE === 'dev'

--- a/lib/deployProfile.js
+++ b/lib/deployProfile.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { legacy, log, style } = require('@serverless/utils/log');
+const { legacy, style } = require('@serverless/utils/log');
+const log = require('./log');
 const { serviceSlug, instanceSlug } = require('./utils');
 const { getDashboardUrl } = require('./dashboard');
 const { getPlatformClientWithAccessKey } = require('./clientUtils');

--- a/lib/deployProfile.js
+++ b/lib/deployProfile.js
@@ -18,8 +18,9 @@ module.exports.configureDeployProfile = async (ctx) => {
 
   if (cliOptions['use-local-credentials']) {
     if (process.env.SLS_DEBUG) {
-      ctx.sls.cli.log('Skipping provider resolution, use-local-credentials option present');
+      legacy.log('Skipping provider resolution, use-local-credentials option present');
     }
+    log.info('Skipping provider resolution, use-local-credentials option present');
     return;
   }
   const stage = cliOptions.stage || provider.getStage();
@@ -57,8 +58,9 @@ module.exports.configureDeployProfile = async (ctx) => {
     });
   } catch (e) {
     if (process.env.SLS_DEBUG) {
-      ctx.sls.cli.log('ignoring profile fetch error', e);
+      legacy.log('ignoring profile fetch error', e);
     }
+    log.debug('provifile fetch error %o', e);
   }
   if (deploymentProfile && deploymentProfile.providerCredentials) {
     ctx.provider.cachedCredentials = deploymentProfile.providerCredentials.secretValue;

--- a/lib/deployProfile.js
+++ b/lib/deployProfile.js
@@ -80,11 +80,6 @@ module.exports.configureDeployProfile = async (ctx) => {
       if (!e.statusCode === '404') {
         throw e;
       }
-      // The platform-client sdk will throw an error for a 404
-      // Log it if we're in debug mode
-      if (process.env.SLS_DEBUG) {
-        ctx.sls.cli.log('ignoring provider credentials error');
-      }
     }
     const providersConfigUrl = `${getDashboardUrl(ctx)}/providers`;
 

--- a/lib/errorHandler.js
+++ b/lib/errorHandler.js
@@ -4,6 +4,8 @@
  * Error Handler
  */
 
+const { legacy } = require('@serverless/utils/log');
+const log = require('./log');
 const serializeError = require('./serializeError');
 const { getDashboardUrl } = require('./dashboard');
 const { parseDeploymentData } = require('./deployment');
@@ -15,13 +17,17 @@ module.exports = function (ctx) {
      * - Handle failed deployments
      */
 
-    ctx.sls.cli.log('Publishing service to the Serverless Dashboard...');
+    legacy.log('Publishing service to the Serverless Dashboard...');
+    log.info('Publishing service to the Serverless Dashboard...');
 
     const deployment = await parseDeploymentData(ctx, 'error', serializeError(error));
 
     await deployment.save();
 
-    ctx.sls.cli.log(
+    legacy.log(
+      `Successfully published your service to the Serverless Dashboard: ${getDashboardUrl(ctx)}`
+    );
+    log.info(
       `Successfully published your service to the Serverless Dashboard: ${getDashboardUrl(ctx)}`
     );
     if (!ctx.state.deployment) {

--- a/lib/errorHandler.test.js
+++ b/lib/errorHandler.test.js
@@ -16,14 +16,9 @@ describe('errorHandler', () => {
 
   it('creates a depoyment with serialized error and saves it', async () => {
     const error = new Error('foobar');
-    const ctx = { sls: { cli: { log: sinon.spy() } }, state: {} };
+    const ctx = { sls: {}, state: {} };
     await errorHandler(ctx)(error);
     expect(parseDeploymentData.args[0][0]).to.deep.equal(ctx);
     expect(parseDeploymentData.args[0][1]).to.equal('error');
-    expect(ctx.sls.cli.log.calledWith('Publishing service to the Serverless Dashboard...')).to.be
-      .true;
-    expect(ctx.sls.cli.log.lastCall.args[0]).includes(
-      'Successfully published your service to the Serverless Dashboard'
-    );
   });
 });

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { log } = require('@serverless/utils/log');
+
+module.exports = log.get('dashboard');

--- a/lib/log.test.js
+++ b/lib/log.test.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { expect } = require('chai');
+const log = require('./log');
+
+describe('lib/log.test.js', () => {
+  it('should expose log methods', async () => {
+    expect(typeof log.info).to.equal('function');
+    expect(typeof log.debug).to.equal('function');
+    expect(typeof log).to.equal('function');
+  });
+});

--- a/lib/login.js
+++ b/lib/login.js
@@ -4,7 +4,8 @@ const open = require('open');
 const { ServerlessSDK } = require('@serverless/platform-client');
 const configUtils = require('@serverless/utils/config');
 const oldLog = require('@serverless/utils/log');
-const { legacy, log, style } = require('@serverless/utils/log');
+const { legacy, style } = require('@serverless/utils/log');
+const log = require('./log');
 const chalk = require('chalk');
 
 module.exports = async function ({ isInteractive } = {}) {

--- a/lib/logout.js
+++ b/lib/logout.js
@@ -2,7 +2,8 @@
 
 const accountUtils = require('@serverless/utils/account');
 const configUtils = require('@serverless/utils/config');
-const { log, legacy } = require('@serverless/utils/log');
+const { legacy } = require('@serverless/utils/log');
+const log = require('./log');
 
 module.exports = async function () {
   const user = configUtils.getLoggedInUser();

--- a/lib/logsCollection.js
+++ b/lib/logsCollection.js
@@ -2,6 +2,8 @@
 
 const chalk = require('chalk');
 const { inspect } = require('util');
+const { legacy } = require('@serverless/utils/log');
+const log = require('./log');
 
 /*
  * Logs Collection
@@ -32,7 +34,8 @@ module.exports = async (ctx) => {
     ctx.sls.service.custom.enterprise &&
     ctx.sls.service.custom.enterprise.collectLambdaLogs === false
   ) {
-    ctx.sls.cli.log('Info: This plugin is not configured to collect AWS Lambda Logs.');
+    legacy.log('Info: This plugin is not configured to collect AWS Lambda Logs.');
+    log.info('This plugin is not configured to collect AWS Lambda Logs.');
     return;
   }
 
@@ -41,7 +44,8 @@ module.exports = async (ctx) => {
     ctx.sls.service.custom.enterprise &&
     ctx.sls.service.custom.enterprise.logIngestMode === 'pull'
   ) {
-    ctx.sls.cli.log('Info: Log ingestion is configured to pull-based ingestion.');
+    legacy.log('Info: Log ingestion is configured to pull-based ingestion.');
+    log.info('Log ingestion is configured to pull-based ingestion.');
     return;
   }
 
@@ -70,11 +74,12 @@ module.exports = async (ctx) => {
     ({ destinationArn } = await sdk.logDestinations.getOrCreate(destinationOpts));
   } catch (e) {
     if (e.message && e.message.includes('not supported in region')) {
-      ctx.sls.cli.log(
+      legacy.log(
         chalk.keyword('orange')(
           `Warning: Lambda log collection is not supported in ${ctx.provider.getRegion()}`
         )
       );
+      log.warning(`Lambda log collection is not supported in ${ctx.provider.getRegion()}`);
       return;
     }
     throw e;

--- a/lib/outputCommand.js
+++ b/lib/outputCommand.js
@@ -3,7 +3,8 @@
 const { isEmpty, isObject } = require('lodash');
 const chalk = require('chalk');
 const cliTable = require('cli-color/columns');
-const { legacy, log, writeText } = require('@serverless/utils/log');
+const { legacy, writeText } = require('@serverless/utils/log');
+const log = require('./log');
 const isAuthenticated = require('./isAuthenticated');
 const throwAuthError = require('./throwAuthError');
 const resolveOutputs = require('./resolveOutputs');

--- a/lib/paramCommand.js
+++ b/lib/paramCommand.js
@@ -3,7 +3,8 @@
 const { isEmpty } = require('lodash');
 const chalk = require('chalk');
 const cliTable = require('cli-color/columns');
-const { legacy, log, writeText } = require('@serverless/utils/log');
+const { legacy, writeText } = require('@serverless/utils/log');
+const log = require('./log');
 const isAuthenticated = require('./isAuthenticated');
 const throwAuthError = require('./throwAuthError');
 const resolveParams = require('./resolveParams');

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -27,8 +27,6 @@ const outputCommand = require('./outputCommand');
 const isAuthenticated = require('./isAuthenticated');
 const throwAuthError = require('./throwAuthError');
 
-const userNodeVersion = Number(process.version.split('.')[0].slice(1));
-
 const unconditionalCommands = new Set([
   'dashboard',
   'generate-event',
@@ -408,11 +406,9 @@ class ServerlessEnterprisePlugin {
           await logout(this);
           break;
         case 'studio:studio':
-          if (userNodeVersion >= 8) {
+          {
             const studio = require('./studio');
             await studio(this);
-          } else {
-            this.sls.cli.log('Node 8 or higher is required to run Serverless Studio.');
           }
           break;
         case 'generate-event:generate-event':

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -3,7 +3,8 @@
 const chalk = require('chalk');
 const _ = require('lodash');
 const { ServerlessSDK } = require('@serverless/platform-client');
-const { legacy, log } = require('@serverless/utils/log');
+const { legacy } = require('@serverless/utils/log');
+const log = require('./log');
 const errorHandler = require('./errorHandler');
 const logsCollection = require('./logsCollection');
 const login = require('./login');

--- a/lib/plugin.test.js
+++ b/lib/plugin.test.js
@@ -80,9 +80,6 @@ describe('plugin', () => {
         org: 'org',
         provider: { variableSyntax: '\\${([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}' },
       },
-      cli: {
-        log: sinon.spy(),
-      },
       processedInput: {
         commands: [],
         options: {
@@ -142,7 +139,6 @@ describe('plugin', () => {
       new Set(['param', 'secrets', 'state', 'output'])
     );
     expect(sls.getProvider.calledWith('aws')).to.be.true;
-    expect(sls.cli.log.callCount).to.equal(0);
   });
 
   it('construct requires org', async () => {
@@ -151,7 +147,6 @@ describe('plugin', () => {
     const instance = new ServerlessEnterprisePlugin(slsClone);
     await instance.asyncInit();
     expect(slsClone.getProvider.calledWith('aws')).to.be.true;
-    expect(sls.cli.log.callCount).to.equal(0);
   });
 
   it('construct disallows variable use', () => {
@@ -160,7 +155,6 @@ describe('plugin', () => {
     expect(() => new ServerlessEnterprisePlugin(slsClone)).to.throw(
       '"app" and "org" in your serverless config can not use the variable system'
     );
-    expect(sls.cli.log.callCount).to.equal(0);
   });
 
   it('routes before:package:createDeploymentArtifacts hook correctly', async () => {

--- a/lib/studio.js
+++ b/lib/studio.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const chokidar = require('chokidar');
+const { legacy } = require('@serverless/utils/log');
 const { isEqual } = require('lodash');
 const { getPlatformClientWithAccessKey } = require('./clientUtils');
 
@@ -86,14 +87,14 @@ module.exports = async function (ctx) {
     return;
   }
 
-  sls.cli.log('Starting Serverless Studio...');
+  legacy.log('Starting Serverless Studio...');
   sls.logDeprecation('STUDIO_COMMAND', '"studio" command will be removed with next major release');
 
   /**
    * As a pseudo-failsafe, don't support the prod stage to limit WebSocket traffic
    */
   if (deployToStage === 'prod') {
-    sls.cli.log("Stage 'prod' cannot be used with 'serverless studio'");
+    legacy.log("Stage 'prod' cannot be used with 'serverless studio'");
     return;
   }
 
@@ -110,8 +111,8 @@ module.exports = async function (ctx) {
   await sdk.events.publish({ event: 'studio.connect', data: { clientType: 'cli' } });
 
   if (autoStage) {
-    sls.cli.log(`Auto stage generation enabled. Will deploy to stage: "${deployToStage}"...`);
-    sls.cli.log(`Note: exiting Studio will remove stage "${deployToStage}"...`);
+    legacy.log(`Auto stage generation enabled. Will deploy to stage: "${deployToStage}"...`);
+    legacy.log(`Note: exiting Studio will remove stage "${deployToStage}"...`);
   }
 
   const disconnect = async () => {
@@ -120,7 +121,7 @@ module.exports = async function (ctx) {
       await sdk.disconnect();
 
       process.stdout.write('\n');
-      sls.cli.log('Disconnected from the Serverless Platform');
+      legacy.log('Disconnected from the Serverless Platform');
     }
   };
 
@@ -132,7 +133,7 @@ module.exports = async function (ctx) {
      */
     if (autoStage) {
       process.stdout.write('\n');
-      sls.cli.log(`Cleaning up stage "${deployToStage}"...`);
+      legacy.log(`Cleaning up stage "${deployToStage}"...`);
       await serverlessExec.remove();
     }
   };
@@ -152,7 +153,7 @@ module.exports = async function (ctx) {
   /**
    * Communicate initial state of the serverless.yml
    */
-  sls.cli.log('Sending initial app state...');
+  legacy.log('Sending initial app state...');
 
   await studio.refreshAppState();
   await studio.publishAppState({
@@ -199,18 +200,18 @@ module.exports = async function (ctx) {
     cwd: '/',
   });
 
-  sls.cli.log('Building function dependency watch list...');
+  legacy.log('Building function dependency watch list...');
 
   await rewatchFiles();
 
-  sls.cli.log(
+  legacy.log(
     `Tracking ${
       Object.keys(serverlessExec.functionToFilenames).length
     } function handler(s), and their dependencies...`
   );
 
   watcher.on('ready', () => {
-    sls.cli.log('Watching for changes...');
+    legacy.log('Watching for changes...');
   });
 
   /**
@@ -231,7 +232,7 @@ module.exports = async function (ctx) {
       possibleServerlessConfigFileVariants.includes(resolvedFilepath) &&
       !studio.appState.isDeploying
     ) {
-      sls.cli.log('serverless configuration changed. Checking for function changes...');
+      legacy.log('serverless configuration changed. Checking for function changes...');
 
       /**
        * Compare the function (names) in the serverless.yml file
@@ -245,12 +246,12 @@ module.exports = async function (ctx) {
       const { functions } = await serverlessExec.info();
 
       if (!isEqual(functions, studio.appState.functions)) {
-        sls.cli.log('Detected function configuration changes...');
-        sls.cli.log(`Stage "${deployToStage}" will be redeployed to reflect these changes...`);
+        legacy.log('Detected function configuration changes...');
+        legacy.log(`Stage "${deployToStage}" will be redeployed to reflect these changes...`);
         await studio.deploy({ isRedeploying: true });
         rewatchFiles();
       } else {
-        sls.cli.log('No function changes detected. Continuing...');
+        legacy.log('No function changes detected. Continuing...');
       }
 
       return;
@@ -273,7 +274,7 @@ module.exports = async function (ctx) {
      * Mark all functions as deploying, and communicate that state
      */
     functionsNeedingDeploy.forEach((functionName) => {
-      sls.cli.log(`${functionName}: changed. Redeploying...`);
+      legacy.log(`${functionName}: changed. Redeploying...`);
       isFunctionDeploying[functionName] = true;
     });
 
@@ -304,7 +305,7 @@ module.exports = async function (ctx) {
 
     if (functionsNeedingDeploy.length > 0) {
       await studio.publishAppState();
-      sls.cli.log('Watching for changes...');
+      legacy.log('Watching for changes...');
     }
   });
 };

--- a/lib/studio/Studio.js
+++ b/lib/studio/Studio.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { legacy } = require('@serverless/utils/log');
+
 class Studio {
   constructor({ sdk, sls, serverlessExec }) {
     this.sdk = sdk;
@@ -85,7 +87,7 @@ class Studio {
         }
       },
     });
-    this.sls.cli.log('Connected to the Serverless Platform');
+    legacy.log('Connected to the Serverless Platform');
   }
 
   async deploy({ isRedeploying, functionName } = {}) {
@@ -94,7 +96,7 @@ class Studio {
     }
 
     if (!functionName) {
-      this.sls.cli.log(
+      legacy.log(
         `${isRedeploying ? 'Re-deploying' : 'Deploying'} to stage "${
           this.serverlessExec.deployToStage
         }". This may take a few minutes...`
@@ -118,7 +120,7 @@ class Studio {
     }
 
     if (!hasDeployFailed && !functionName) {
-      this.sls.cli.log(`Successfully deployed stage "${this.serverlessExec.deployToStage}"`);
+      legacy.log(`Successfully deployed stage "${this.serverlessExec.deployToStage}"`);
     }
 
     this.updateAppState({ isDeploying: false });

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -258,15 +258,6 @@ except Exception as error:
 };
 
 const wrap = async (ctx) => {
-  // Check if we support the provider
-  if (ctx.sls.service.provider.name !== 'aws') {
-    ctx.sls.cli.log(
-      chalk.keyword('orange')(
-        'Warning: The Serverless Dashboard does not currently support this provider.'
-      )
-    );
-  }
-
   /*
    * Prepare Functions
    */

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -11,6 +11,8 @@ const fs = require('fs-extra');
 const path = require('path');
 const _ = require('lodash');
 const JSZip = require('jszip');
+const { legacy } = require('@serverless/utils/log');
+const log = require('./log');
 const { getOrCreateAccessKeyForOrg } = require('./clientUtils');
 const { addTree, writeZip } = require('./zipTree');
 const { version } = require('../package.json');
@@ -312,20 +314,26 @@ const wrap = async (ctx) => {
     };
   }
   if (unsupportedRuntimes.size) {
-    ctx.sls.cli.log(
+    legacy.log(
       chalk.keyword('orange')(
         `Warning the Serverless Dashboard doesn't support the following runtime${
           unsupportedRuntimes.size === 1 ? '' : 's'
         }: ${Array.from(unsupportedRuntimes).join(', ')}`
       )
     );
+    log.warning(
+      `Serverless Dashboard doesn't support the following runtime${
+        unsupportedRuntimes.size === 1 ? '' : 's'
+      }: ${Array.from(unsupportedRuntimes).join(', ')}`
+    );
   }
   if (hasImageFunction) {
-    ctx.sls.cli.log(
+    legacy.log(
       chalk.keyword('orange')(
         "Warning the Serverless Dashboard doesn't support functions that reference AWS ECR images"
       )
     );
+    log.warning("Serverless Dashboard doesn't support functions that reference AWS ECR images");
   }
 
   /*

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -3,7 +3,6 @@
 const { expect } = require('chai');
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
-const chalk = require('chalk');
 const path = require('path');
 const configUtils = require('@serverless/utils/config');
 const runServerless = require('../test/run-serverless');
@@ -77,8 +76,6 @@ describe('wrap - wrap', () => {
 
   afterEach(() => sinon.resetHistory());
   it('wraps copies js sdk & calls wrapper', async () => {
-    const log = sinon.spy();
-
     const ctx = {
       deploymentUid: 'deploymentUid',
       state: {},
@@ -114,7 +111,6 @@ describe('wrap - wrap', () => {
             },
           },
         },
-        cli: { log },
       },
     };
     await wrap(ctx);
@@ -176,13 +172,6 @@ describe('wrap - wrap', () => {
       },
     });
     expect(ctx.sls.service.package).to.deep.equal({ include: ['s_*.js', 'serverless_sdk/**'] });
-    expect(
-      ctx.sls.cli.log.calledWith(
-        chalk.keyword('orange')(
-          "Warning the Serverless Dashboard doesn't support the following runtime: unsupported6.66"
-        )
-      )
-    ).to.be.true;
     expect(fs.writeFileSync.callCount).to.equal(3);
     expect(
       fs.writeFileSync.calledWith(


### PR DESCRIPTION
When fiddling with tests in v6 branch, I've discovered we've missed that.

Additionally exposed a namespaced logger to be used in the context of this plugin