### PR TITLE
Tests: Refactor variable tests

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -177,34 +177,8 @@ class ServerlessEnterprisePlugin {
     const legacyResolveOutputVariable = variables.getValueFromDashboardOutputs(this);
 
     this.configurationVariablesSources = {
-      param: {
-        async resolve({ address }) {
-          return {
-            value: await (async () => {
-              try {
-                return await legacyResolveParamVariable(`param:${address}`);
-              } catch (error) {
-                if (error.code === 'PARAM_NOT_FOUND') return null;
-                throw error;
-              }
-            })(),
-          };
-        },
-      },
-      output: {
-        async resolve({ address }) {
-          return {
-            value: await (async () => {
-              try {
-                return await legacyResolveOutputVariable(`output:${address}`);
-              } catch (error) {
-                if (error.message.includes(' not found')) return null;
-                throw error;
-              }
-            })(),
-          };
-        },
-      },
+      param: { resolve: variables.paramResolve.bind(this) },
+      output: { resolve: variables.outputResolve.bind(this) },
     };
 
     // TODO: Remove with next major

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -77,7 +77,7 @@ const getValueFromDashboardOutputs = (ctx) => async (variableString) => {
   const outputName = key.split('.')[1];
   const subkey = key.slice(outputName.length + 2);
   if (!ctx.sls.enterpriseEnabled) throwAuthError(ctx.sls);
-  const value = resolveOutput(outputName, {
+  const value = await resolveOutput(outputName, {
     service,
     app,
     org: ctx.sls.service.org,

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -93,4 +93,28 @@ const getValueFromDashboardOutputs = (ctx) => async (variableString) => {
 module.exports = {
   getValueFromDashboardParams,
   getValueFromDashboardOutputs,
+  async paramResolve({ address }) {
+    return {
+      value: await (async () => {
+        try {
+          return await getValueFromDashboardParams(this)(`param:${address}`);
+        } catch (error) {
+          if (error.code === 'PARAM_NOT_FOUND') return null;
+          throw error;
+        }
+      })(),
+    };
+  },
+  async outputResolve({ address }) {
+    return {
+      value: await (async () => {
+        try {
+          return await getValueFromDashboardOutputs(this)(`output:${address}`);
+        } catch (error) {
+          if (error.message.includes(' not found')) return null;
+          throw error;
+        }
+      })(),
+    };
+  },
 };

--- a/lib/variables.test.js
+++ b/lib/variables.test.js
@@ -27,15 +27,6 @@ describe('variables', () => {
       ],
     });
     ({ getValueFromDashboardParams, getValueFromDashboardOutputs, resolveParams } = requireUncached(
-      [
-        require.resolve('./variables'),
-        require.resolve('./resolveParams'),
-        require.resolve('./resolveOutput'),
-        require.resolve('./isAuthenticated'),
-        require.resolve('./clientUtils'),
-        require.resolve('@serverless/platform-client'),
-        require.resolve('@serverless/utils/config'),
-      ],
       () => {
         Object.assign(require('@serverless/utils/config'), {
           getLoggedInUser: () => ({ accessKeys: { org: 'accesskey' } }),

--- a/lib/variables.test.js
+++ b/lib/variables.test.js
@@ -1,229 +1,111 @@
 'use strict';
 
 const { expect } = require('chai');
-const requireUncached = require('ncjsm/require-uncached');
-const sinon = require('sinon');
+const path = require('path');
+const configUtils = require('@serverless/utils/config');
+const runServerless = require('../test/run-serverless');
+const setupServerless = require('../test/setupServerless');
 
-describe('lib/variables.test.js', () => {
-  let getStateVariableStub;
-  let getDeployProfileStub;
-  let getValueFromDashboardParams;
-  let getValueFromDashboardOutputs;
-  let resolveParams;
+const platformClientPath = require.resolve('@serverless/platform-client');
+const configUtilsPath = require.resolve('@serverless/utils/config');
 
-  before(() => {
-    getStateVariableStub = sinon.stub().callsFake(({ outputName }) => {
-      if (outputName === 'withsubkey') {
-        return Promise.resolve({ value: { subkey: 'seeeeeccrreeeetttt' } });
-      }
-      return Promise.resolve({ value: 'simple seeeeeccrreeeetttt' });
-    });
-    getDeployProfileStub = sinon.stub().resolves({
-      secretValues: [
-        {
-          secretName: 'name',
-          secretProperties: { value: 'secretValue' },
-        },
-      ],
-    });
-    ({ getValueFromDashboardParams, getValueFromDashboardOutputs, resolveParams } = requireUncached(
-      () => {
-        Object.assign(require('@serverless/utils/config'), {
-          getLoggedInUser: () => ({ accessKeys: { org: 'accesskey' } }),
-        });
-        Object.assign(require('@serverless/platform-client'), {
-          ServerlessSDK: class ServerlessSDK {
-            constructor() {
-              this.services = {
-                getStateVariable: getStateVariableStub,
-              };
-
-              this.deploymentProfiles = {
-                get: getDeployProfileStub,
-              };
+const modulesCacheStub = {
+  [configUtilsPath]: {
+    ...configUtils,
+    getLoggedInUser: () => ({
+      accessKeys: { 'some-org': 'accesskey', 'testinteractivecli': 'accesskey' },
+    }),
+  },
+  [platformClientPath]: {
+    ServerlessSDK: class ServerlessSDK {
+      constructor() {
+        this.services = {
+          getStateVariable: async ({
+            variableName,
+            appName,
+            serviceName,
+            stageName,
+            regionName,
+          }) => {
+            if (variableName === 'sub') {
+              return { value: { key: 'nested' } };
             }
-
-            async getOrgByName() {
-              return { orgUid: 'abcd-1234' };
-            }
-            async getParamsByOrgServiceInstance() {
-              return {};
-            }
+            return {
+              value:
+                `name:${variableName}|app:${appName}|` +
+                `service:${serviceName}|stage:${stageName}|region:${regionName}`,
+            };
           },
-        });
-        return {
-          ...require('./variables'),
-          resolveParams: require('./resolveParams'),
+        };
+        this.deploymentProfiles = {
+          get: async () => ({}),
         };
       }
-    ));
+      async getOrgByName() {
+        return { orgUid: 'foobar' };
+      }
+      async getParamsByOrgServiceInstance() {
+        return {
+          result: [{ paramName: 'name', paramValue: 'secretValue', paramType: 'intsances' }],
+        };
+      }
+    },
+  },
+};
+
+describe('lib/variables.test.js', () => {
+  let configurationInput;
+
+  before(async () => {
+    ({
+      serverless: { configurationInput },
+    } = await runServerless({
+      fixture: 'aws-monitored-service',
+      command: 'print',
+      configExt: {
+        custom: {
+          paramTest: '${param:name}',
+          output1: '${output:service.key}',
+          output4: '${output:app:stage:region:service.key}',
+          outputSubKey: '${output:service.sub.key}',
+        },
+      },
+      modulesCacheStub,
+      hooks: {
+        beforeInstanceRun: async (serverless) => {
+          const serverlessDir = (await setupServerless()).root;
+
+          const resolveVariables = require(path.resolve(
+            serverlessDir,
+            'lib/configuration/variables'
+          ));
+          const { dashboardPlugin } = serverless.pluginManager;
+          const variables = require('./variables');
+          await resolveVariables({
+            servicePath: serverless.serviceDir,
+            configuration: serverless.configurationInput,
+            options: {},
+            sources: {
+              param: { resolve: variables.paramResolve.bind(dashboardPlugin) },
+              output: { resolve: variables.outputResolve.bind(dashboardPlugin) },
+            },
+          });
+        },
+      },
+    }));
   });
 
-  describe('params', () => {
-    afterEach(() => {
-      getDeployProfileStub.resetHistory();
-      resolveParams.clear();
-    });
-
-    const ctx = {
-      sls: {
-        service: {
-          app: 'app',
-          service: 'service',
-          org: 'org',
-        },
-        processedInput: {
-          commands: [],
-          options: {
-            cliOptions: [],
-          },
-        },
-        enterpriseEnabled: true,
-      },
-      provider: {
-        getStage: () => 'stage',
-        getRegion: () => 'region',
-      },
-      state: { secretsUsed: new Set() },
-    };
-
-    it('gets a param from dashboard', async () => {
-      const value = await getValueFromDashboardParams(ctx)('param:name');
-      expect(value).to.deep.equal('secretValue');
-      expect(ctx.state.secretsUsed).to.deep.equal(new Set(['name']));
-      expect(getDeployProfileStub.args[0]).to.deep.equal([
-        {
-          stageName: 'stage',
-          orgName: 'org',
-          appName: 'app',
-        },
-      ]);
-    });
-
-    it('gets a secret from dashboard', async () => {
-      const value = await getValueFromDashboardParams(ctx)('secrets:name');
-      expect(value).to.deep.equal('secretValue');
-      expect(ctx.state.secretsUsed).to.deep.equal(new Set(['name']));
-      expect(getDeployProfileStub.args[0]).to.deep.equal([
-        {
-          stageName: 'stage',
-          orgName: 'org',
-          appName: 'app',
-        },
-      ]);
-    });
-
-    it('doesnt break during login command', async () => {
-      const value = await getValueFromDashboardParams({
-        ...ctx,
-        sls: {
-          ...ctx.sls,
-          processedInput: { commands: ['login'] },
-        },
-      })('secrets:name');
-      expect(value).to.deep.equal('');
-      expect(ctx.state.secretsUsed).to.deep.equal(new Set(['name']));
-      expect(getDeployProfileStub.callCount).to.equal(0);
-    });
+  it('should resolve param source', async () => {
+    expect(configurationInput.custom.paramTest).to.equal('secretValue');
   });
 
-  describe('outputs', () => {
-    afterEach(() => {
-      getStateVariableStub.resetHistory();
-    });
-    const ctx = {
-      sls: {
-        service: {
-          app: 'app',
-          service: 'service',
-          org: 'org',
-        },
-        processedInput: {
-          commands: [],
-        },
-        enterpriseEnabled: true,
-      },
-      provider: {
-        getStage: () => 'stage',
-        getRegion: () => 'region',
-      },
-      state: { secretsUsed: new Set() },
-    };
-
-    it('gets a state output from dashboard', async () => {
-      const value = await getValueFromDashboardOutputs(ctx)('state:service.name');
-      expect(value).to.deep.equal('simple seeeeeccrreeeetttt');
-      expect(getStateVariableStub.args[0]).to.deep.equal([
-        {
-          stageName: 'stage',
-          orgName: 'org',
-          appName: 'app',
-          serviceName: 'service',
-          variableName: 'name',
-          regionName: 'region',
-        },
-      ]);
-    });
-
-    it('gets a state output from dashboard with long options but left blank', async () => {
-      const value = await getValueFromDashboardOutputs(ctx)('state::::service.name');
-      expect(value).to.deep.equal('simple seeeeeccrreeeetttt');
-      expect(getStateVariableStub.args[0]).to.deep.equal([
-        {
-          stageName: 'stage',
-          orgName: 'org',
-          appName: 'app',
-          serviceName: 'service',
-          variableName: 'name',
-          regionName: 'region',
-        },
-      ]);
-    });
-
-    it('gets a state output from dashboard with long options but left only stage blank', async () => {
-      const value = await getValueFromDashboardOutputs(ctx)(
-        'state:diff-app::diff-region:service.name'
-      );
-      expect(value).to.deep.equal('simple seeeeeccrreeeetttt');
-      expect(getStateVariableStub.args[0]).to.deep.equal([
-        {
-          stageName: 'stage',
-          orgName: 'org',
-          appName: 'diff-app',
-          serviceName: 'service',
-          variableName: 'name',
-          regionName: 'diff-region',
-        },
-      ]);
-    });
-
-    it('gets a state output from dashboard with app/stage/region options', async () => {
-      const value = await getValueFromDashboardOutputs(ctx)(
-        'state:diff-app:diff-stage:diff-region:service.name'
-      );
-      expect(value).to.deep.equal('simple seeeeeccrreeeetttt');
-      expect(getStateVariableStub.args[0]).to.deep.equal([
-        {
-          stageName: 'diff-stage',
-          orgName: 'org',
-          appName: 'diff-app',
-          serviceName: 'service',
-          variableName: 'name',
-          regionName: 'diff-region',
-        },
-      ]);
-    });
-
-    it('doesnt break during login command', async () => {
-      const value = await getValueFromDashboardOutputs({
-        ...ctx,
-        sls: {
-          ...ctx.sls,
-          processedInput: { commands: ['login'] },
-        },
-      })('state:service.name');
-      expect(value).to.deep.equal('');
-      expect(getStateVariableStub.callCount).to.equal(0);
-    });
+  it('should resolve output source', async () => {
+    expect(configurationInput.custom.output1).to.equal(
+      'name:key|app:some-aws-service-app|service:service|stage:dev|region:us-east-1'
+    );
+    expect(configurationInput.custom.output4).to.equal(
+      'name:key|app:app|service:service|stage:stage|region:region'
+    );
+    expect(configurationInput.custom.outputSubKey).to.equal('nested');
   });
 });

--- a/lib/variables.test.js
+++ b/lib/variables.test.js
@@ -4,7 +4,7 @@ const { expect } = require('chai');
 const requireUncached = require('ncjsm/require-uncached');
 const sinon = require('sinon');
 
-describe('variables', () => {
+describe('lib/variables.test.js', () => {
   let getStateVariableStub;
   let getDeployProfileStub;
   let getValueFromDashboardParams;
@@ -59,7 +59,7 @@ describe('variables', () => {
     ));
   });
 
-  describe('variables - getValueFromDashboardParams', () => {
+  describe('params', () => {
     afterEach(() => {
       getDeployProfileStub.resetHistory();
       resolveParams.clear();
@@ -127,7 +127,7 @@ describe('variables', () => {
     });
   });
 
-  describe('variables - getValueFromDashboardOutputs', () => {
+  describe('outputs', () => {
     afterEach(() => {
       getStateVariableStub.resetHistory();
     });

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@serverless/eslint-config": "^4.0.0",
-    "@serverless/test": "^8.4.0",
+    "@serverless/test": "^8.5.1",
     "aws-sdk": "^2.1020.0",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
_Needed for stage params functionality (so reliable tests can be ensured)_

Ideally, as variable resolution now happens not in the context of the `Serverless` instance, those tests should also be constructed independently. Still, all dashboard plugin machinery (as authentication against the dashboard, which is needed for variables resolution), is still baked into the plugin which in normal circumstances is initialized by serverless instance.
Therefore I've set up a new test with `runServerless` util, in the sense that instance is initialized and then variables are resolved with help of the internal dashboard plugin instance.

At some point, it'll be nice to generalize all needed parts, and refactor these tests so no hacky `runServerless` run is made.

Additionally during that, a bug was detected and fixed. Resolution of nested `output` property (as via `${output:service.nested.key}` was not working, as property access was made on the unresolved promise

