### PR TITLE
Support for `params` configuration

### DIFF
--- a/lib/paramCommand.js
+++ b/lib/paramCommand.js
@@ -43,8 +43,8 @@ module.exports = {
       legacy.log(`No '${name}' parameter stored`);
       log.notice.skip(`No "${name}"" parameter stored`);
     } else {
-      legacy.write(`${params[name]}\n`);
-      writeText(params[name]);
+      legacy.write(`${params[name].value}\n`);
+      writeText(params[name].value);
     }
   },
   list: async (context) => {
@@ -55,9 +55,12 @@ module.exports = {
     } else {
       legacy.log('Stored parameters:');
       legacy.write(
-        `\n${cliTable([[chalk.bold('Name'), chalk.bold('Value')], ...Object.entries(params)])}\n`
+        `\n${cliTable([
+          [chalk.bold('Name'), chalk.bold('Value')],
+          ...Object.entries(params).map(([key, { value }]) => [key, value]),
+        ])}\n`
       );
-      writeText(Object.entries(params).map(([name, value]) => `${name}: ${value}`));
+      writeText(Object.entries(params).map(([name, { value }]) => `${name}: ${value}`));
     }
   },
 };

--- a/lib/paramCommand.test.js
+++ b/lib/paramCommand.test.js
@@ -19,15 +19,7 @@ const modulesCacheStub = {
     ServerlessSDK: class ServerlessSDK {
       constructor() {
         this.deploymentProfiles = {
-          get: async () => ({
-            secretValues: [
-              { secretName: 'first-param-name', secretProperties: { value: 'first-param-value' } },
-              {
-                secretName: 'second-param-name',
-                secretProperties: { value: 'second-param-value' },
-              },
-            ],
-          }),
+          get: async () => ({}),
         };
       }
 
@@ -40,7 +32,17 @@ const modulesCacheStub = {
       }
 
       async getParamsByOrgServiceInstance() {
-        return { result: [], metadata: {}, errors: [] };
+        return {
+          result: [
+            { paramName: 'first-param-name', paramValue: 'first-param-value' },
+            {
+              paramName: 'second-param-name',
+              paramValue: 'second-param-value',
+            },
+          ],
+          metadata: {},
+          errors: [],
+        };
       }
     },
   },

--- a/lib/paramCommand.test.js
+++ b/lib/paramCommand.test.js
@@ -34,10 +34,15 @@ const modulesCacheStub = {
       async getParamsByOrgServiceInstance() {
         return {
           result: [
-            { paramName: 'first-param-name', paramValue: 'first-param-value' },
+            {
+              paramName: 'first-param-name',
+              paramValue: 'first-param-value',
+              paramType: 'instances',
+            },
             {
               paramName: 'second-param-name',
               paramValue: 'second-param-value',
+              paramType: 'instances',
             },
           ],
           metadata: {},
@@ -137,8 +142,16 @@ describe('paramCommand', () => {
     it('Should support `--service` and --region CLI param to talk to Parameters backend', async () => {
       const getParamsStub = sinon.stub().returns({
         result: [
-          { paramName: 'paramServiceOne', paramValue: 'paramServiceValueOne' },
-          { paramName: 'paramServiceTwo', paramValue: 'paramServiceValueTwo' },
+          {
+            paramName: 'paramServiceOne',
+            paramValue: 'paramServiceValueOne',
+            paramType: 'instances',
+          },
+          {
+            paramName: 'paramServiceTwo',
+            paramValue: 'paramServiceValueTwo',
+            paramType: 'instances',
+          },
         ],
       });
       const { output } = await runServerless({

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -169,36 +169,10 @@ class ServerlessEnterprisePlugin {
         this
       ),
     };
-    const legacyResolveParamVariable = variables.getValueFromDashboardParams(this);
-    const legacyResolveOutputVariable = variables.getValueFromDashboardOutputs(this);
 
     this.configurationVariablesSources = {
       param: { resolve: variables.paramResolve.bind(this) },
       output: { resolve: variables.outputResolve.bind(this) },
-    };
-
-    // TODO: Remove with next major
-    this.variableResolvers = {
-      param: {
-        resolver: legacyResolveParamVariable,
-        serviceName: 'Serverless Parameters',
-        isDisabledAtPrepopulation: true,
-      },
-      secrets: {
-        resolver: legacyResolveParamVariable,
-        serviceName: 'Serverless Secrets',
-        isDisabledAtPrepopulation: true,
-      },
-      output: {
-        resolver: legacyResolveOutputVariable,
-        serviceName: 'Serverless Outputs',
-        isDisabledAtPrepopulation: true,
-      },
-      state: {
-        resolver: legacyResolveOutputVariable,
-        serviceName: 'Serverless Outputs',
-        isDisabledAtPrepopulation: true,
-      },
     };
 
     // Check if dashboard is configured

--- a/lib/plugin.test.js
+++ b/lib/plugin.test.js
@@ -134,9 +134,6 @@ describe('plugin', () => {
         'param:list:list',
       ].sort()
     );
-    expect(new Set(Object.keys(instance.variableResolvers))).to.deep.equal(
-      new Set(['param', 'secrets', 'state', 'output'])
-    );
     expect(sls.getProvider.calledWith('aws')).to.be.true;
   });
 

--- a/lib/resolveParams.js
+++ b/lib/resolveParams.js
@@ -16,8 +16,8 @@ module.exports = memoizee(
     );
     const params = Object.create(null);
     if (parametersResponse.result && parametersResponse.result.length) {
-      for (const { paramName, paramValue } of parametersResponse.result) {
-        params[paramName] = paramValue;
+      for (const { paramName, paramValue, paramType } of parametersResponse.result) {
+        params[paramName] = { value: paramValue, type: paramType.slice(0, -1) };
       }
     }
 

--- a/lib/resolveParams.js
+++ b/lib/resolveParams.js
@@ -19,18 +19,6 @@ module.exports = memoizee(
       for (const { paramName, paramValue } of parametersResponse.result) {
         params[paramName] = paramValue;
       }
-    } else {
-      const deploymentProfile = await sdk.deploymentProfiles.get({
-        orgName: org,
-        appName: app,
-        stageName: stage,
-      });
-      for (const {
-        secretName: name,
-        secretProperties: { value },
-      } of deploymentProfile.secretValues) {
-        params[name] = value;
-      }
     }
 
     return params;

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -24,8 +24,8 @@ const resolveInput = function (ctx) {
 
 // functions for new way of getting variables
 const getValueFromDashboardParams = (ctx) => async (variableString) => {
-  const variableName = variableString.slice(variableString.indexOf(':') + 1);
-  ctx.state.secretsUsed.add(variableName);
+  const paramName = variableString.slice(variableString.indexOf(':') + 1);
+  ctx.state.secretsUsed.add(paramName);
   if (
     ctx.sls.processedInput.commands[0] === 'login' ||
     ctx.sls.processedInput.commands[0] === 'logout'
@@ -34,11 +34,11 @@ const getValueFromDashboardParams = (ctx) => async (variableString) => {
   }
 
   if (!ctx.sls.enterpriseEnabled) throwAuthError(ctx.sls);
-  const secrets = await resolveParams(resolveInput(ctx));
-  if (!secrets[variableName]) {
+  const params = await resolveParams(resolveInput(ctx));
+  if (!params[paramName]) {
     throw new ctx.sls.classes.Error(`$\{${variableString}} not defined`, 'PARAM_NOT_FOUND');
   }
-  return secrets[variableName];
+  return params[paramName];
 };
 
 const getValueFromDashboardOutputs = (ctx) => async (variableString) => {

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -32,10 +32,39 @@ const getValueFromDashboardParams = (ctx) => async (paramName) => {
     return '';
   }
 
-  if (!ctx.sls.enterpriseEnabled) throwAuthError(ctx.sls);
-  const params = await resolveParams(resolveInput(ctx));
-  if (!params[paramName]) return null;
-  return params[paramName].value;
+  const stage = ctx.provider.getStage();
+  const paramsConfig = new Map(Object.entries(ctx.sls.configurationInput.params || {}));
+
+  // 1. Local, stage specific params
+  const paramsStageConfig = new Map(Object.entries(paramsConfig.get(stage) || {}));
+
+  if (paramsStageConfig.get(paramName) != null) return paramsStageConfig.get(paramName);
+
+  // 2. Console, instance specific params
+  const dashboardParams =
+    (ctx.sls.enterpriseEnabled && (await resolveParams(resolveInput(ctx)))) || {};
+  const dashboardInstanceParams = new Map(
+    Object.entries(dashboardParams)
+      .filter(([, { type }]) => type === 'instance')
+      .map(([key, { value }]) => [key, value])
+  );
+  if (dashboardInstanceParams.has(paramName)) return dashboardInstanceParams.get(paramName);
+
+  // 3. Local, default params
+  const paramsDefaultConfig = new Map(Object.entries(paramsConfig.get('default') || {}));
+
+  if (paramsDefaultConfig.get(paramName) != null) return paramsDefaultConfig.get(paramName);
+
+  // 4. Console, service specific params
+  const dashboardServiceParams = new Map(
+    Object.entries(dashboardParams)
+      .filter(([, { type }]) => type === 'service')
+      .map(([key, { value }]) => [key, value])
+  );
+
+  if (dashboardServiceParams.has(paramName)) return dashboardServiceParams.get(paramName);
+
+  return null;
 };
 
 const getValueFromDashboardOutputs = (ctx) => async (outputAddress) => {

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -38,7 +38,7 @@ const getValueFromDashboardParams = (ctx) => async (variableString) => {
   if (!params[paramName]) {
     throw new ctx.sls.classes.Error(`$\{${variableString}} not defined`, 'PARAM_NOT_FOUND');
   }
-  return params[paramName];
+  return params[paramName].value;
 };
 
 const getValueFromDashboardOutputs = (ctx) => async (variableString) => {

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -23,8 +23,7 @@ const resolveInput = function (ctx) {
 };
 
 // functions for new way of getting variables
-const getValueFromDashboardParams = (ctx) => async (variableString) => {
-  const paramName = variableString.slice(variableString.indexOf(':') + 1);
+const getValueFromDashboardParams = (ctx) => async (paramName) => {
   ctx.state.secretsUsed.add(paramName);
   if (
     ctx.sls.processedInput.commands[0] === 'login' ||
@@ -35,20 +34,18 @@ const getValueFromDashboardParams = (ctx) => async (variableString) => {
 
   if (!ctx.sls.enterpriseEnabled) throwAuthError(ctx.sls);
   const params = await resolveParams(resolveInput(ctx));
-  if (!params[paramName]) {
-    throw new ctx.sls.classes.Error(`$\{${variableString}} not defined`, 'PARAM_NOT_FOUND');
-  }
+  if (!params[paramName]) return null;
   return params[paramName].value;
 };
 
-const getValueFromDashboardOutputs = (ctx) => async (variableString) => {
+const getValueFromDashboardOutputs = (ctx) => async (outputAddress) => {
   if (
     ctx.sls.processedInput.commands[0] === 'login' ||
     ctx.sls.processedInput.commands[0] === 'logout'
   ) {
     return '';
   }
-  const variableParts = variableString.split(':').slice(1);
+  const variableParts = outputAddress.split(':');
   let service;
   let key;
   let app = ctx.sls.service.app;
@@ -77,13 +74,20 @@ const getValueFromDashboardOutputs = (ctx) => async (variableString) => {
   const outputName = key.split('.')[1];
   const subkey = key.slice(outputName.length + 2);
   if (!ctx.sls.enterpriseEnabled) throwAuthError(ctx.sls);
-  const value = await resolveOutput(outputName, {
-    service,
-    app,
-    org: ctx.sls.service.org,
-    stage,
-    region,
-  });
+  const value = await (async () => {
+    try {
+      return await resolveOutput(outputName, {
+        service,
+        app,
+        org: ctx.sls.service.org,
+        stage,
+        region,
+      });
+    } catch (error) {
+      if (error.message.includes(' not found')) return null;
+      throw error;
+    }
+  })();
   if (subkey) {
     return _.get(value, subkey);
   }
@@ -91,30 +95,14 @@ const getValueFromDashboardOutputs = (ctx) => async (variableString) => {
 };
 
 module.exports = {
-  getValueFromDashboardParams,
-  getValueFromDashboardOutputs,
   async paramResolve({ address }) {
     return {
-      value: await (async () => {
-        try {
-          return await getValueFromDashboardParams(this)(`param:${address}`);
-        } catch (error) {
-          if (error.code === 'PARAM_NOT_FOUND') return null;
-          throw error;
-        }
-      })(),
+      value: await getValueFromDashboardParams(this)(address),
     };
   },
   async outputResolve({ address }) {
     return {
-      value: await (async () => {
-        try {
-          return await getValueFromDashboardOutputs(this)(`output:${address}`);
-        } catch (error) {
-          if (error.message.includes(' not found')) return null;
-          throw error;
-        }
-      })(),
+      value: await getValueFromDashboardOutputs(this)(address),
     };
   },
 };

--- a/lib/variables.test.js
+++ b/lib/variables.test.js
@@ -46,7 +46,28 @@ const modulesCacheStub = {
       }
       async getParamsByOrgServiceInstance() {
         return {
-          result: [{ paramName: 'name', paramValue: 'secretValue', paramType: 'intsances' }],
+          result: [
+            {
+              paramName: 'stageLocal',
+              paramValue: 'unexpectedDashboardInstance',
+              paramType: 'instances',
+            },
+            {
+              paramName: 'dashboardInstance',
+              paramValue: 'dashboardInstanceValue',
+              paramType: 'instances',
+            },
+            {
+              paramName: 'defaultLocal',
+              paramValue: 'unexpectedDashboardService',
+              paramType: 'services',
+            },
+            {
+              paramName: 'dashboardService',
+              paramValue: 'dashboardServiceValue',
+              paramType: 'services',
+            },
+          ],
         };
       }
     },
@@ -64,10 +85,23 @@ describe('lib/variables.test.js', () => {
       command: 'print',
       configExt: {
         custom: {
-          paramTest: '${param:name}',
+          paramStageLocal: '${param:stageLocal}',
+          paramDashboardInstance: '${param:dashboardInstance}',
+          paramDefaultLocal: '${param:defaultLocal}',
+          paramDashboardService: '${param:dashboardService}',
           output1: '${output:service.key}',
           output4: '${output:app:stage:region:service.key}',
           outputSubKey: '${output:service.sub.key}',
+        },
+        params: {
+          default: {
+            defaultLocal: 'defaultLocalValue',
+            stageLocal: 'unexpectedDefaultLocal',
+            dashboardInstance: 'unexpectedDefaultLocal',
+          },
+          dev: {
+            stageLocal: 'stageLocalValue',
+          },
         },
       },
       modulesCacheStub,
@@ -96,7 +130,10 @@ describe('lib/variables.test.js', () => {
   });
 
   it('should resolve param source', async () => {
-    expect(configurationInput.custom.paramTest).to.equal('secretValue');
+    expect(configurationInput.custom.paramStageLocal).to.equal('stageLocalValue');
+    expect(configurationInput.custom.paramDashboardInstance).to.equal('dashboardInstanceValue');
+    expect(configurationInput.custom.paramDefaultLocal).to.equal('defaultLocalValue');
+    expect(configurationInput.custom.paramDashboardService).to.equal('dashboardServiceValue');
   });
 
   it('should resolve output source', async () => {


### PR DESCRIPTION
_Depends on https://github.com/serverless/serverless/pull/10400 being merged first_

So far `param` variable source resolved purely from params as stored on the dashboard side. This PR enhances the support so params can also be configured in service configuration at `params` property.

Additionally:
- Remove support for params as stored at deployment profile (such setup is no longer accessible in Dashboard, and is automatically overshadowed by eventual params set at service or stage level)
- Remove support for old Framework variables resolver