### PR TITLE
Fix resolution of default runtime

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -86,7 +86,7 @@ class ServerlessEnterprisePlugin {
               collectLambdaLogs: { type: 'boolean' },
               compressLogs: { type: 'boolean' },
               disableAwsSpans: { type: 'boolean' },
-              disableFrameworkInstrumentation: { type: 'boolean' },
+              disableFrameworksInstrumentation: { type: 'boolean' },
               disableHttpSpans: { type: 'boolean' },
               logAccessIamRole: { $ref: '#/definitions/awsArnString' },
               logIngestMode: { enum: ['push', 'pull'] },

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -275,7 +275,7 @@ const wrap = async (ctx) => {
     }
     const runtime = functionConfig.runtime
       ? functionConfig.runtime
-      : ctx.sls.service.provider.runtime;
+      : ctx.sls.service.provider.runtime || 'nodejs12.x';
 
     if (!supportedRuntime(runtime)) {
       unsupportedRuntimes.add(runtime);

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -547,4 +547,29 @@ describe('wrap #2', () => {
       "Serverless Dashboard doesn't support functions that reference AWS ECR images"
     );
   });
+
+  it('Should resolve default runtime', async () => {
+    const {
+      cfTemplate: { Resources: cfResources },
+    } = await runServerless({
+      fixture: 'function',
+      configExt: {
+        disabledDeprecations: ['CHANGE_OF_DEFAULT_RUNTIME_TO_NODEJS14X'],
+        provider: { runtime: null },
+      },
+      command: 'package',
+      modulesCacheStub,
+      awsRequestStubMap: {
+        STS: {
+          getCallerIdentity: {
+            ResponseMetadata: { RequestId: 'ffffffff-ffff-ffff-ffff-ffffffffffff' },
+            UserId: 'XXXXXXXXXXXXXXXXXXXXX',
+            Account: '999999999999',
+            Arn: 'arn:aws:iam::999999999999:user/test',
+          },
+        },
+      },
+    });
+    expect(cfResources.FunctionLambdaFunction.Properties.Handler).to.equal('s_function.handler');
+  });
 });

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -512,12 +512,20 @@ describe('wrap #2', () => {
     const { stdoutData } = await runServerless({
       fixture: 'function',
       command: 'invoke local',
+      configExt: {
+        custom: {
+          enterprise: {
+            disableAwsSpans: true,
+            disableHttpSpans: true,
+            disableFrameworksInstrumentation: true,
+          },
+        },
+      },
       options: { function: 'function' },
       modulesCacheStub,
     });
     expect(stdoutData).to.not.include('SERVERLESS_ENTERPRISE');
   });
-
   it('Should handle functions that reference images', async () => {
     const { stdoutData } = await runServerless({
       fixture: 'function',


### PR DESCRIPTION
I was diagnosing CI fail in the v6 branch, and it appears, plugin fails to wrap lambdas when no `runtime` is configured in a service, while per Framework rules we fall back to default `node12.x`.

We've also show not very friendly message then:

<img width="960" alt="Screenshot 2021-12-22 at 13 18 15" src="https://user-images.githubusercontent.com/122434/147091675-14202c0f-e451-4d00-b0a0-169849080222.png">

This patch ensures the plugin will work correctly with no runtime setup.

Ideally, this _default_ should not be hardcoded here, but read from Framework. Still, currently, we do not expose Framework defaults. It'll be fixed with https://github.com/serverless/serverless/issues/8107 (when that's addressed, it'll be good to revisit this patch)

--- 

Additionally, newly reported CI fail in context of this PR exposed other issues:

There's a `runServelress` based on these that involves local invocation, which naturally loads SDK wrapper, and that involves loading instrumentation that manipulates native Node.js require. Unfortunately, this has side effects, and made modules stubbing for `runServeless` run in certain cases not effective.

Luckily this instrumentation can be turned off via configuration options, therefore ensuring those options on, on tests setup.

This exposed that we have a typo in the definition of `disableFrameworksInstrumentation` property. Fixed that as well