### PR TITLE
feat: Support for CLI options during `param` variable resolution

### DIFF
--- a/lib/param-command.js
+++ b/lib/param-command.js
@@ -5,6 +5,11 @@ const { writeText, style } = require('@serverless/utils/log');
 const log = require('./log');
 const resolveParams = require('./resolve-params');
 
+const overridenByCliMessage =
+  'This Serverless Console parameter is overridden by provided CLI param';
+const overridenByConfigMessage =
+  'This Serverless Console parameter is overridden in service configuration';
+
 module.exports = {
   get: async (context) => {
     const cliOptions = context.sls.processedInput.options;
@@ -27,9 +32,9 @@ module.exports = {
     } else {
       writeText(params[name].value);
       if (params[name].isOverriden) {
-        log.notice(
-          style.aside('This Serverless Console parameter is overridden in service configuration')
-        );
+        const message =
+          params[name].type === 'cli' ? overridenByCliMessage : overridenByConfigMessage;
+        log.notice(style.aside(message));
       }
     }
   },
@@ -45,14 +50,11 @@ module.exports = {
     if (isEmpty(params)) {
       log.notice.skip('No parameters stored');
     } else {
-      for (const [name, { value, isOverriden }] of Object.entries(params)) {
+      for (const [name, { value, isOverriden, type }] of Object.entries(params)) {
         writeText(`${name}: ${value}`);
         if (isOverriden) {
-          log.notice(
-            style.aside(
-              '   This Serverless Console parameter is overridden in service configuration'
-            )
-          );
+          const message = `   ${type === 'cli' ? overridenByCliMessage : overridenByConfigMessage}`;
+          log.notice(style.aside(message));
         }
       }
     }

--- a/lib/param-command.test.js
+++ b/lib/param-command.test.js
@@ -121,6 +121,37 @@ describe('paramCommand', () => {
       expect(output).to.include('dashboardServiceValue');
     });
 
+    it('Should support overriding with `--param` CLI param', async () => {
+      const { output } = await runServerless({
+        fixture: 'aws-monitored-service',
+        command: 'param list',
+        configExt: {
+          params: {
+            default: {
+              defaultLocal: 'defaultLocalValue',
+              stageLocal: 'unexpectedDefaultLocal',
+              dashboardInstance: 'unexpectedDefaultLocal',
+            },
+            dev: {
+              stageLocal: 'stageLocalValue',
+            },
+          },
+        },
+        options: {
+          param: ['dashboardInstance=overridenbycli'],
+        },
+        modulesCacheStub,
+      });
+      expect(output).to.include('stageLocal');
+      expect(output).to.include('stageLocalValue');
+      expect(output).to.include('dashboardInstance');
+      expect(output).to.include('overridenbycli');
+      expect(output).to.include('defaultLocal');
+      expect(output).to.include('defaultLocalValue');
+      expect(output).to.include('dashboardService');
+      expect(output).to.include('dashboardServiceValue');
+    });
+
     it('Should support `--service` and --region CLI param to talk to Parameters backend', async () => {
       const getParamsStub = sinon.stub().returns({
         result: [
@@ -241,6 +272,23 @@ describe('paramCommand', () => {
       });
 
       expect(output).to.include('stageLocalValue');
+    });
+    it('Should support overriding with `--param` CLI param', async () => {
+      const { output } = await runServerless({
+        noService: true,
+        command: 'param get',
+        options: {
+          name: 'dashboardInstance',
+          org: 'some-org',
+          app: 'some-app',
+          stage: 'foo',
+          service: 'some-service',
+          param: ['dashboardInstance=overridenbycli'],
+        },
+        modulesCacheStub,
+      });
+
+      expect(output).to.include('overridenbycli');
     });
   });
 });

--- a/lib/resolve-params.js
+++ b/lib/resolve-params.js
@@ -80,8 +80,24 @@ module.exports = memoizee(async (context) => {
   );
 
   const resultParams = Object.create(null);
+
+  if (context.sls.processedInput.options.param) {
+    const regex = /(?<key>[^=]+)=(?<value>.+)/;
+    for (const item of context.sls.processedInput.options.param) {
+      const res = item.match(regex);
+      if (!res) {
+        throw new context.sls.classes.Error(
+          `Encountered invalid "--param" CLI option value: "${item}". Supported format: "--param='<key>=<val>'"`,
+          'INVALID_CLI_PARAM_FORMAT'
+        );
+      }
+      resultParams[res.groups.key] = { value: res.groups.value.trimEnd(), type: 'cli' };
+    }
+  }
+
   for (const [name, value] of Object.entries(configParams.get(stage) || {})) {
     if (value == null) continue;
+    if (resultParams[name] != null) continue;
     resultParams[name] = { value, type: 'configServiceStage' };
   }
   const dashboardParams = await resolveDashboardParams(resolveInput(context));

--- a/lib/variables.test.js
+++ b/lib/variables.test.js
@@ -83,8 +83,12 @@ describe('lib/variables.test.js', () => {
     } = await runServerless({
       fixture: 'aws-monitored-service',
       command: 'print',
+      options: {
+        param: ['fromCli=cliValue'],
+      },
       configExt: {
         custom: {
+          paramCli: '${param:fromCli}',
           paramStageLocal: '${param:stageLocal}',
           paramDashboardInstance: '${param:dashboardInstance}',
           paramDefaultLocal: '${param:defaultLocal}',
@@ -130,6 +134,7 @@ describe('lib/variables.test.js', () => {
   });
 
   it('should resolve param source', async () => {
+    expect(configurationInput.custom.paramCli).to.equal('cliValue');
     expect(configurationInput.custom.paramStageLocal).to.equal('stageLocalValue');
     expect(configurationInput.custom.paramDashboardInstance).to.equal('dashboardInstanceValue');
     expect(configurationInput.custom.paramDefaultLocal).to.equal('defaultLocalValue');


### PR DESCRIPTION
In order to successfully run tests, this PR needs to be merged first: https://github.com/serverless/serverless/pull/10713

Addresses: https://github.com/serverless/serverless/issues/9817