### PR TITLE
chore: Upgrade `@serverless/test` to `v10`

### DIFF
--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -4,6 +4,8 @@ const { expect } = require('chai');
 const zlib = require('zlib');
 const wait = require('timers-ext/promise/sleep');
 const awsRequest = require('@serverless/test/aws-request');
+const CloudWatchLogsService = require('aws-sdk').CloudWatchLogs;
+const LambdaService = require('aws-sdk').LambdaService;
 const hasFailed = require('@serverless/test/has-failed');
 const log = require('log').get('test');
 const { ServerlessSDK } = require('@serverless/platform-client');
@@ -125,7 +127,7 @@ describe('integration: wrapper', () => {
       throw new Error(`Unable to fetch providers: ${providerCredentials.errors}`);
     }
     lambdaService = {
-      name: 'Lambda',
+      client: LambdaService,
       params: {
         region: process.env.SERVERLESS_PLATFORM_TEST_REGION || 'us-east-1',
         credentials: providerDetails,
@@ -133,7 +135,7 @@ describe('integration: wrapper', () => {
     };
 
     cloudwatchLogsService = {
-      name: 'CloudWatchLogs',
+      client: CloudWatchLogsService,
       params: lambdaService.params,
     };
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@serverless/eslint-config": "^4.0.0",
-    "@serverless/test": "^9.0.0",
+    "@serverless/test": "^10.0.1",
     "aws-sdk": "^2.1064.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
@@ -41,7 +41,7 @@
     "lint-staged": "^10.5.4",
     "log": "^6.3.1",
     "log-node": "^8.0.3",
-    "mocha": "^8.4.0",
+    "mocha": "^9.2.0",
     "nyc": "^15.1.0",
     "prettier": "^2.5.1",
     "process-utils": "^4.0.0",


### PR DESCRIPTION
In order to address the issue with invalid temp directory returned by `os.tmpdir` - e.g. like here: https://github.com/serverless/dashboard-plugin/runs/5233156891?check_suite_focus=true