### PR TITLE
Console related changes

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -55,9 +55,8 @@ const hasExistingDeployments = async (service, provider) => {
 
 const dashboardHandler = async (ctx) => {
   const { service } = ctx.sls;
-  const isServiceIntegratedWithDashboard = Boolean(service.org);
 
-  if (!isServiceIntegratedWithDashboard) {
+  if (!ctx.isDashboardEnabled) {
     log.notice.skip(
       'This service does not use the Serverless Dashboard. Run "serverless" to get started.'
     );

--- a/lib/dashboard.test.js
+++ b/lib/dashboard.test.js
@@ -37,6 +37,7 @@ const commonCtx = {
       app: 'app',
     },
   },
+  isDashboardEnabled: true,
 };
 
 describe('dashboard', () => {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -91,19 +91,21 @@ class ServerlessEnterprisePlugin {
       });
     }
 
-    const {
-      service,
-      processedInput: { options: cliOptions },
-    } = this.sls;
-    service.isDashboardMonitoringPreconfigured = Boolean(service.org);
-    if (service.isDashboardMonitoringPreconfigured) {
-      service.isDashboardAppPreconfigured = Boolean(service.app);
-      service.isDashboardMonitoringOverridenByCli =
-        (cliOptions.org && cliOptions.org !== service.org) ||
-        (cliOptions.app && cliOptions.app !== service.app);
+    if (this.isDashboardEnabled) {
+      const {
+        service,
+        processedInput: { options: cliOptions },
+      } = this.sls;
+      service.isDashboardMonitoringPreconfigured = Boolean(service.org);
+      if (service.isDashboardMonitoringPreconfigured) {
+        service.isDashboardAppPreconfigured = Boolean(service.app);
+        service.isDashboardMonitoringOverridenByCli =
+          (cliOptions.org && cliOptions.org !== service.org) ||
+          (cliOptions.app && cliOptions.app !== service.app);
+      }
+      if (cliOptions.org) service.org = cliOptions.org;
+      if (cliOptions.app) service.app = cliOptions.app;
     }
-    if (cliOptions.org) service.org = cliOptions.org;
-    if (cliOptions.app) service.app = cliOptions.app;
 
     // Rely on commands schema as configured in "serverless"
     const commandsSchema = sls._commandsSchema;
@@ -373,6 +375,7 @@ class ServerlessEnterprisePlugin {
     }
     const currentCommand = this.sls.processedInput.commands[0];
     if (
+      this.isDashboardEnabled &&
       missingConfigSettings.length === 0 &&
       isAuthenticated() &&
       !unconditionalCommands.has(currentCommand)
@@ -384,6 +387,16 @@ class ServerlessEnterprisePlugin {
     // https://github.com/serverless/serverless/blob/f0ccf6441ace7b5cc524e774f025a39c3c0667f2/lib/classes/PluginManager.js#L78
     this.provider = this.sls.getProvider('aws');
     if (this.sls.enterpriseEnabled) await configureDeployProfile(this);
+  }
+
+  get isDashboardEnabled() {
+    const {
+      service,
+      processedInput: { options: cliOptions },
+      isDashboardEnabled,
+    } = this.sls;
+    if (isDashboardEnabled != null) return isDashboardEnabled;
+    return Boolean(service.org || cliOptions.org);
   }
 }
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -321,7 +321,7 @@ class ServerlessEnterprisePlugin {
           break;
         case 'login:login':
           await login(this.sls.service);
-          if (!this.sls.service.org || this.sls.service.app) {
+          if (!this.sls.service.org || !this.sls.service.app) {
             log.notice();
             log.notice('Run "serverless" to add your service to the Serverless Dashboard');
           }


### PR DESCRIPTION
After introduction of console, dashboard should not be enabled when `console: true` is found in settings.

This PR ensures that internal logic depends on eventually provided by the Framework logic on wether dashboard should be enabled or not (implemented in https://github.com/serverless/serverless/pull/10752)

Additionally fixed conditional responsible for showing `serverless` command promotion