### PR TITLE
chore: Upgrade `simple-git` to `v3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node-fetch": "^2.6.7",
     "open": "^7.4.2",
     "semver": "^7.3.5",
-    "simple-git": "^2.48.0",
+    "simple-git": "^3.3.0",
     "type": "^2.6.0",
     "uuid": "^8.3.2",
     "yamljs": "^0.3.0"


### PR DESCRIPTION
Related to dependabot alert: https://github.com/serverless/dashboard-plugin/security/dependabot/8

The changelog of `simple-git` suggests that the only breaking change was around the structure of the codebase, I think it is a safe upgrade to new major of this dependency. There was a deprecated mehtod `silent` in the past but we've removed the use of it.

Closes: https://github.com/serverless/dashboard-plugin/issues/682