### PR TITLE
Console related improvements

### DIFF
--- a/lib/ensure-dashboard-enabled.js
+++ b/lib/ensure-dashboard-enabled.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const isAuthenticated = require('./is-authenticated');
+const throwAuthError = require('./throw-auth-error');
+
+module.exports = (context) => {
+  if (!isAuthenticated()) throwAuthError(context.sls);
+  if (!context.isDashboardEnabled) {
+    throw new context.sls.classes.Error(
+      'Missing dashboard configuration ("org" and "app") or integration is disabled',
+      'DASHBOARD_DISABLED'
+    );
+  }
+};

--- a/lib/output-command.js
+++ b/lib/output-command.js
@@ -3,12 +3,12 @@
 const { isEmpty, isObject } = require('lodash');
 const { writeText } = require('@serverless/utils/log');
 const log = require('./log');
-const isAuthenticated = require('./is-authenticated');
-const throwAuthError = require('./throw-auth-error');
+const ensureDashboardEnabled = require('./ensure-dashboard-enabled');
 const resolveOutputs = require('./resolve-outputs');
 const resolveOutput = require('./resolve-output');
 
 const resolveInput = function (ctx) {
+  ensureDashboardEnabled(ctx);
   const {
     provider,
     sls: {
@@ -17,11 +17,6 @@ const resolveInput = function (ctx) {
       classes: { Error: ServerlessError },
     },
   } = ctx;
-
-  if (!isAuthenticated()) throwAuthError(ctx.sls);
-
-  if (!org) throw new ServerlessError('Missing `org` setting', 'DASHBOARD_MISSING_ORG');
-  if (!app) throw new ServerlessError('Missing `app` setting', 'DASHBOARD_MISSING_APP');
 
   const serviceName = cliOptions.service || service;
   if (!serviceName) {

--- a/lib/output-command.test.js
+++ b/lib/output-command.test.js
@@ -96,7 +96,7 @@ describe('outputCommand', () => {
         });
         throw new Error('Unexpected');
       } catch (error) {
-        if (error.code !== 'DASHBOARD_MISSING_ORG') throw error;
+        if (error.code !== 'DASHBOARD_DISABLED') throw error;
       }
     });
     it('Should crash when no app is configured', async () => {
@@ -109,7 +109,7 @@ describe('outputCommand', () => {
         });
         throw new Error('Unexpected');
       } catch (error) {
-        if (error.code !== 'DASHBOARD_MISSING_APP') throw error;
+        if (error.code !== 'DASHBOARD_DISABLED') throw error;
       }
     });
     it('Should crash when no service is configured', async () => {
@@ -227,7 +227,7 @@ describe('outputCommand', () => {
         });
         throw new Error('Unexpected');
       } catch (error) {
-        if (error.code !== 'DASHBOARD_MISSING_ORG') throw error;
+        if (error.code !== 'DASHBOARD_DISABLED') throw error;
       }
     });
     it('Should crash when no app is configured', async () => {
@@ -240,7 +240,7 @@ describe('outputCommand', () => {
         });
         throw new Error('Unexpected');
       } catch (error) {
-        expect(error.code).to.equal('DASHBOARD_MISSING_APP');
+        expect(error.code).to.equal('DASHBOARD_DISABLED');
       }
     });
     it('Should crash when no service is configured', async () => {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -91,21 +91,19 @@ class ServerlessEnterprisePlugin {
       });
     }
 
-    if (this.isDashboardEnabled) {
-      const {
-        service,
-        processedInput: { options: cliOptions },
-      } = this.sls;
-      service.isDashboardMonitoringPreconfigured = Boolean(service.org);
-      if (service.isDashboardMonitoringPreconfigured) {
-        service.isDashboardAppPreconfigured = Boolean(service.app);
-        service.isDashboardMonitoringOverridenByCli =
-          (cliOptions.org && cliOptions.org !== service.org) ||
-          (cliOptions.app && cliOptions.app !== service.app);
-      }
-      if (cliOptions.org) service.org = cliOptions.org;
-      if (cliOptions.app) service.app = cliOptions.app;
+    const {
+      service,
+      processedInput: { options: cliOptions },
+    } = this.sls;
+    service.isDashboardMonitoringPreconfigured = Boolean(service.org);
+    if (service.isDashboardMonitoringPreconfigured) {
+      service.isDashboardAppPreconfigured = Boolean(service.app);
+      service.isDashboardMonitoringOverridenByCli =
+        (cliOptions.org && cliOptions.org !== service.org) ||
+        (cliOptions.app && cliOptions.app !== service.app);
     }
+    if (cliOptions.org) service.org = cliOptions.org;
+    if (cliOptions.app) service.app = cliOptions.app;
 
     // Rely on commands schema as configured in "serverless"
     const commandsSchema = sls._commandsSchema;
@@ -364,6 +362,11 @@ class ServerlessEnterprisePlugin {
   }
 
   async asyncInit() {
+    // this.provider, intentionally not set in constructor, as then it affects plugin validation
+    // in serverless, which will discard plugin when command not run in service context:
+    // https://github.com/serverless/serverless/blob/f0ccf6441ace7b5cc524e774f025a39c3c0667f2/lib/classes/PluginManager.js#L78
+    this.provider = this.sls.getProvider('aws');
+
     if (
       this.sls.processedInput.options['help-interactive'] ||
       this.sls.processedInput.options.help
@@ -383,18 +386,14 @@ class ServerlessEnterprisePlugin {
     }
     const currentCommand = this.sls.processedInput.commands[0];
     if (
-      this.isDashboardEnabled &&
       missingConfigSettings.length === 0 &&
       isAuthenticated() &&
       !unconditionalCommands.has(currentCommand)
     ) {
-      this.sls.enterpriseEnabled = true;
+      // Support providers wih dashboard explicitly disabled (console case)
+      await configureDeployProfile(this);
+      this.sls.enterpriseEnabled = this.isDashboardEnabled;
     }
-    // this.provider, intentionally not set in constructor, as then it affects plugin validation
-    // in serverless, which will discard plugin when command not run in service context:
-    // https://github.com/serverless/serverless/blob/f0ccf6441ace7b5cc524e774f025a39c3c0667f2/lib/classes/PluginManager.js#L78
-    this.provider = this.sls.getProvider('aws');
-    if (this.sls.enterpriseEnabled) await configureDeployProfile(this);
   }
 
   get isDashboardEnabled() {
@@ -403,8 +402,10 @@ class ServerlessEnterprisePlugin {
       processedInput: { options: cliOptions },
       isDashboardEnabled,
     } = this.sls;
-    if (isDashboardEnabled != null) return isDashboardEnabled;
-    return Boolean(service.org || cliOptions.org);
+    if (isDashboardEnabled != null) {
+      return isDashboardEnabled && Boolean(service.app || cliOptions.app);
+    }
+    return Boolean((service.org || cliOptions.org) && (service.app || cliOptions.app));
   }
 }
 


### PR DESCRIPTION
- Load providers unconditionally when user is authenticated and service is configured with `org` and `app` 
- Generalize dashboard setup validation into one util