### PR TITLE
refactor: Use `patterns` instead of `include`

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -391,15 +391,15 @@ const wrap = async (ctx) => {
         _.get(ctx.sls.service, 'package.individually', false)
       )
     ) {
-      // add include directives for handler file & sdk lib
+      // add patterns directives for handler file & sdk lib
       if (ctx.sls.service.functions[fn].package === undefined) {
         ctx.sls.service.functions[fn].package = {};
       }
-      if (ctx.sls.service.functions[fn].package.include === undefined) {
-        ctx.sls.service.functions[fn].package.include = [];
+      if (ctx.sls.service.functions[fn].package.patterns === undefined) {
+        ctx.sls.service.functions[fn].package.patterns = [];
       }
-      ctx.sls.service.functions[fn].package.include.push(`${func.entryNew}.${func.extension}`);
-      ctx.sls.service.functions[fn].package.include.push('serverless_sdk/**');
+      ctx.sls.service.functions[fn].package.patterns.push(`${func.entryNew}.${func.extension}`);
+      ctx.sls.service.functions[fn].package.patterns.push('serverless_sdk/**');
     }
   }
 
@@ -419,7 +419,7 @@ const wrap = async (ctx) => {
     await addTree(zip, 'serverless_sdk');
     await writeZip(zip, ctx.sls.service.package.artifact);
   }
-  // add include directives for handler file & sdk lib
+  // add patterns directives for handler file & sdk lib
   else if (!_.get(ctx.sls.service, 'package.individually', false)) {
     let extension = 'js';
     if (supportedPythonRuntime(ctx.sls.service.provider.runtime)) {
@@ -428,11 +428,11 @@ const wrap = async (ctx) => {
     if (ctx.sls.service.package === undefined) {
       ctx.sls.service.package = {};
     }
-    if (ctx.sls.service.package.include === undefined) {
-      ctx.sls.service.package.include = [];
+    if (ctx.sls.service.package.patterns === undefined) {
+      ctx.sls.service.package.patterns = [];
     }
-    ctx.sls.service.package.include.push(`s_*.${extension}`);
-    ctx.sls.service.package.include.push('serverless_sdk/**');
+    ctx.sls.service.package.patterns.push(`s_*.${extension}`);
+    ctx.sls.service.package.patterns.push('serverless_sdk/**');
   }
 };
 

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -174,7 +174,7 @@ describe('wrap - wrap', () => {
         handler: 'handlerFile.handlerFunc',
       },
     });
-    expect(ctx.sls.service.package).to.deep.equal({ include: ['s_*.js', 'serverless_sdk/**'] });
+    expect(ctx.sls.service.package).to.deep.equal({ patterns: ['s_*.js', 'serverless_sdk/**'] });
     expect(fs.writeFileSync.callCount).to.equal(3);
     expect(
       fs.writeFileSync.calledWith(
@@ -450,7 +450,7 @@ except Exception as error:
         package: { artifact: 'bundle.zip' },
       },
     });
-    expect(ctx.sls.service.package).to.deep.equal({ include: ['s_*.js', 'serverless_sdk/**'] });
+    expect(ctx.sls.service.package).to.deep.equal({ patterns: ['s_*.js', 'serverless_sdk/**'] });
     expect(fs.writeFileSync.callCount).to.equal(1);
     expect(
       fs.writeFileSync.calledWith(
@@ -556,14 +556,14 @@ try {
         runtime: 'python3.6',
         handler: 's_dunc.handler',
         package: {
-          include: ['s_dunc.py', 'serverless_sdk/**'],
+          patterns: ['s_dunc.py', 'serverless_sdk/**'],
         },
       },
       func: {
         runtime: 'nodejs8.10',
         handler: 's_func.handler',
         package: {
-          include: ['s_func.js', 'serverless_sdk/**'],
+          patterns: ['s_func.js', 'serverless_sdk/**'],
         },
       },
     });


### PR DESCRIPTION
Related to https://github.com/juanjoDiaz/serverless-plugin-warmup/issues/310