### PR TITLE
Update simple-git from 3.7.0 to 3.16.0 to mitigate RCE security risk.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node-fetch": "^2.6.7",
     "open": "^7.4.2",
     "semver": "^7.3.7",
-    "simple-git": "^3.7.0",
+    "simple-git": "^3.16.0",
     "type": "^2.6.0",
     "uuid": "^8.3.2",
     "yamljs": "^0.3.0"


### PR DESCRIPTION
Hey folks! I created this [issue](https://github.com/serverless/dashboard-plugin/issues/702), but figured I could tackle it myself real quick.

**Context**
Snyk has identified that simple-git has [remote code execution](https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-3177391) issue in versions less than 3.16.0. This repo needs simple-git updated.

More info here: https://security.snyk.io/package/npm/simple-git

This PR updates `simple-git` from `^3.7.0` to `^3.16.0`