### PR TITLE
Upgrade child-process-ext to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@serverless/event-mocks": "^1.1.1",
     "@serverless/platform-client": "^4.3.2",
     "@serverless/utils": "^6.8.2",
-    "child-process-ext": "^2.1.1",
+    "child-process-ext": "^3.0.1",
     "chokidar": "^3.5.3",
     "flat": "^5.0.2",
     "fs-extra": "^9.1.0",


### PR DESCRIPTION
* Upgraded `child-process-ext` to `3.0.1` to address security vulnerability with `semver` (via `cross-spawn` transitive dependency).

fixes https://github.com/serverless/dashboard-plugin/issues/708