### PR TITLE
feat: Add support to disable wrapping manually, automatically disable or ESM projects, and for python projects with 3.11

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -174,6 +174,8 @@ jobs:
           npm run build
       - name: Unit tests (isolated)
         run: npm run test:isolated -- -b
+        env:
+          SERVERLESS_PLATFORM_STAGE: dev
       - name: SDK JS Unit tests (isolated)
         run: |
           cd sdk-js

--- a/lib/deployment/parse.test.js
+++ b/lib/deployment/parse.test.js
@@ -1631,6 +1631,10 @@ describe('parseDeploymentData #2', () => {
             this.frameworkDeployments = {
               create: async () => ({}),
             };
+
+            this.organizations = {
+              get: async () => ({}),
+            };
           }
         },
       },

--- a/lib/deployment/parse.test.js
+++ b/lib/deployment/parse.test.js
@@ -1586,6 +1586,10 @@ describe('parseDeploymentData #2', () => {
           accessKeys: { testinteractivecli: 'accesskey' },
         }),
       },
+      [require.resolve('@serverless/utils/api-request')]: {
+        ...require('@serverless/utils/api-request'),
+        apiRequest: async () => {},
+      },
       [require.resolve('@serverless/platform-client')]: {
         ServerlessSDK: class ServerlessSDK {
           constructor() {

--- a/lib/deployment/parse.test.js
+++ b/lib/deployment/parse.test.js
@@ -1586,10 +1586,9 @@ describe('parseDeploymentData #2', () => {
           accessKeys: { testinteractivecli: 'accesskey' },
         }),
       },
-      [require.resolve('@serverless/utils/api-request')]: {
-        ...require('@serverless/utils/api-request'),
-        apiRequest: async () => {},
-      },
+      '@serverless/utils/api-request': async () => ({
+        // apiRequest: async () => {},
+      }),
       [require.resolve('@serverless/platform-client')]: {
         ServerlessSDK: class ServerlessSDK {
           constructor() {

--- a/lib/deployment/parse.test.js
+++ b/lib/deployment/parse.test.js
@@ -1586,11 +1586,13 @@ describe('parseDeploymentData #2', () => {
           accessKeys: { testinteractivecli: 'accesskey' },
         }),
       },
-      '@serverless/utils/api-request': async () => [
-        {
-          vendorAccount: '377024778620',
-        },
-      ],
+      '@serverless/utils/api-request': async () => ({
+        integrations: [
+          {
+            vendorAccount: '377024778620',
+          },
+        ],
+      }),
       [require.resolve('@serverless/platform-client')]: {
         ServerlessSDK: class ServerlessSDK {
           constructor() {

--- a/lib/deployment/parse.test.js
+++ b/lib/deployment/parse.test.js
@@ -1586,9 +1586,11 @@ describe('parseDeploymentData #2', () => {
           accessKeys: { testinteractivecli: 'accesskey' },
         }),
       },
-      '@serverless/utils/api-request': async () => ({
-        // apiRequest: async () => {},
-      }),
+      '@serverless/utils/api-request': async () => [
+        {
+          vendorAccount: '377024778620',
+        },
+      ],
       [require.resolve('@serverless/platform-client')]: {
         ServerlessSDK: class ServerlessSDK {
           constructor() {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -84,6 +84,7 @@ class ServerlessEnterprisePlugin {
               disableHttpSpans: { type: 'boolean' },
               logAccessIamRole: { $ref: '#/definitions/awsArnString' },
               logIngestMode: { enum: ['push', 'pull'] },
+              disableWrapping: { type: 'boolean' },
             },
             additionalProperties: false,
           },

--- a/lib/wrap-clean.js
+++ b/lib/wrap-clean.js
@@ -7,7 +7,7 @@
 
 const fs = require('fs-extra');
 const path = require('path');
-const { shouldWrap, shouldWrapFunction } = require('./wrap-utils');
+const { shouldWrap } = require('./wrap-utils');
 
 module.exports = async (ctx) => {
   if (!shouldWrap(ctx)) {
@@ -20,10 +20,6 @@ module.exports = async (ctx) => {
 
   for (const func of Object.keys(ctx.state.functions)) {
     const fn = ctx.state.functions[func];
-
-    if (!shouldWrapFunction(ctx, fn)) {
-      continue;
-    }
 
     let file;
     if (fn.runtime.includes('node')) {

--- a/lib/wrap-clean.js
+++ b/lib/wrap-clean.js
@@ -10,7 +10,7 @@ const path = require('path');
 const { shouldWrap, shouldWrapFunction } = require('./wrap-utils');
 
 module.exports = async (ctx) => {
-  if (shouldWrap(ctx)) {
+  if (!shouldWrap(ctx)) {
     return;
   }
   // Clear assets (serverless-sdk)

--- a/lib/wrap-clean.js
+++ b/lib/wrap-clean.js
@@ -7,8 +7,12 @@
 
 const fs = require('fs-extra');
 const path = require('path');
+const { shouldWrap, shouldWrapFunction } = require('./wrap-utils');
 
 module.exports = async (ctx) => {
+  if (shouldWrap(ctx)) {
+    return;
+  }
   // Clear assets (serverless-sdk)
   if (fs.pathExistsSync(ctx.state.pathAssets)) {
     fs.removeSync(ctx.state.pathAssets);
@@ -16,6 +20,10 @@ module.exports = async (ctx) => {
 
   for (const func of Object.keys(ctx.state.functions)) {
     const fn = ctx.state.functions[func];
+
+    if (!shouldWrapFunction(ctx, fn)) {
+      continue;
+    }
 
     let file;
     if (fn.runtime.includes('node')) {

--- a/lib/wrap-clean.test.js
+++ b/lib/wrap-clean.test.js
@@ -8,13 +8,20 @@ const path = require('path');
 describe('wrapClean', () => {
   let fs;
   let wrapClean;
+  let wrapUtils;
   before(() => {
     fs = {
       pathExistsSync: sinon.stub().returns(true),
       removeSync: sinon.spy(),
+      existsSync: sinon.stub().onCall(0).returns(false).onCall(1).returns(true),
+    };
+    wrapUtils = {
+      shouldWrap: sinon.stub().returns(true),
+      shouldWrapFunction: sinon.stub().returns(true),
     };
     wrapClean = proxyquire('./wrap-clean', {
       'fs-extra': fs,
+      './wrap-utils': wrapUtils,
     });
   });
 

--- a/lib/wrap-utils.js
+++ b/lib/wrap-utils.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const fs = require('fs-extra');
+const path = require('path');
+
+const shouldWrap = (ctx) => {
+  if (
+    ctx.sls.service.custom &&
+    ctx.sls.service.custom.enterprise &&
+    ctx.sls.service.custom.enterprise.disableWrapping
+  ) {
+    return false;
+  }
+
+  const pkgJsonPath = `${ctx.sls.config.servicePath}/package.json`;
+
+  if (fs.existsSync(pkgJsonPath)) {
+    const pkgJSON = JSON.parse(fs.readFileSync(pkgJsonPath));
+    if (pkgJSON.type && pkgJSON.type === 'module') {
+      return false;
+    }
+  }
+  return true;
+};
+
+const shouldWrapFunction = (ctx, functionConfig) => {
+  const runtime = functionConfig.runtime
+    ? functionConfig.runtime
+    : ctx.sls.service.provider.runtime || 'nodejs14.x';
+
+  if (runtime.includes('python')) {
+    return true;
+  }
+
+  if (runtime.includes('nodejs')) {
+    const handlerPath = functionConfig.handler.split('.').slice(0, -1).join('.');
+    if (fs.existsSync(path.join(ctx.sls.config.servicePath, `${handlerPath}.js`))) {
+      return true;
+    }
+    if (fs.existsSync(path.join(ctx.sls.config.servicePath, `${handlerPath}.mjs`))) {
+      return false;
+    }
+  }
+
+  return false;
+};
+module.exports = { shouldWrap, shouldWrapFunction };

--- a/lib/wrap-utils.js
+++ b/lib/wrap-utils.js
@@ -5,6 +5,7 @@ const path = require('path');
 
 const shouldWrap = (ctx) => {
   if (
+    ctx.sls.service &&
     ctx.sls.service.custom &&
     ctx.sls.service.custom.enterprise &&
     ctx.sls.service.custom.enterprise.disableWrapping

--- a/lib/wrap-utils.test.js
+++ b/lib/wrap-utils.test.js
@@ -153,6 +153,8 @@ describe('wrap - wrap-utils', () => {
     fs.existsSync = sinon.stub().returns(true);
 
     const result = wrapUtils.shouldWrapFunction(ctx, functionConfig);
+    // eslint-disable-next-line no-console
+    console.log(`Args: ${fs.existsSync.args}`);
     expect(result).to.be.true;
     expect(fs.existsSync.calledWith('/tmp/fake/src/index.js')).to.be.true;
     expect(fs.readFileSync.notCalled).to.be.true;

--- a/lib/wrap-utils.test.js
+++ b/lib/wrap-utils.test.js
@@ -3,6 +3,7 @@
 const { expect } = require('chai');
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
+const os = require('os');
 
 describe('wrap - wrap-utils', () => {
   let fs;
@@ -153,10 +154,12 @@ describe('wrap - wrap-utils', () => {
     fs.existsSync = sinon.stub().returns(true);
 
     const result = wrapUtils.shouldWrapFunction(ctx, functionConfig);
-    // eslint-disable-next-line no-console
-    console.log(`Args: ${fs.existsSync.args}`);
     expect(result).to.be.true;
-    expect(fs.existsSync.calledWith('/tmp/fake/src/index.js')).to.be.true;
+    if (os.platform() === 'win32') {
+      expect(fs.existsSync.calledWith('\\tmp\\fake\\src\\index.js')).to.be.true;
+    } else {
+      expect(fs.existsSync.calledWith('/tmp/fake/src/index.js')).to.be.true;
+    }
     expect(fs.readFileSync.notCalled).to.be.true;
   });
 
@@ -182,8 +185,13 @@ describe('wrap - wrap-utils', () => {
 
     const result = wrapUtils.shouldWrapFunction(ctx, functionConfig);
     expect(result).to.be.false;
-    expect(fs.existsSync.calledWith('/tmp/fake/src/index.js')).to.be.true;
-    expect(fs.existsSync.calledWith('/tmp/fake/src/index.mjs')).to.be.true;
+    if (os.platform() === 'win32') {
+      expect(fs.existsSync.calledWith('\\tmp\\fake\\src\\index.js')).to.be.true;
+      expect(fs.existsSync.calledWith('\\tmp\\fake\\src\\index.mjs')).to.be.true;
+    } else {
+      expect(fs.existsSync.calledWith('/tmp/fake/src/index.js')).to.be.true;
+      expect(fs.existsSync.calledWith('/tmp/fake/src/index.mjs')).to.be.true;
+    }
     expect(fs.readFileSync.notCalled).to.be.true;
   });
 

--- a/lib/wrap-utils.test.js
+++ b/lib/wrap-utils.test.js
@@ -1,0 +1,214 @@
+'use strict';
+
+const { expect } = require('chai');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+
+describe('wrap - wrap-utils', () => {
+  let fs;
+  let wrapUtils;
+
+  before(() => {
+    fs = {
+      writeFileSync: sinon.spy(),
+      pathExistsSync: sinon.stub().returns(true),
+      removeSync: () => {},
+      ensureDirSync: () => {},
+      copySync: () => {},
+      readFile: sinon.stub().resolves('zipcontents'),
+      readFileSync: sinon.stub().returns('{"type": "module"}'),
+      existsSync: sinon.stub().returns(true),
+    };
+
+    wrapUtils = proxyquire('./wrap-utils', {
+      'fs-extra': fs,
+      '@noCallThru': true,
+    });
+  });
+
+  afterEach(() => sinon.resetHistory());
+
+  it('evaluates package.json type when determining to not wrap service', () => {
+    const ctx = {
+      sls: {
+        config: {
+          servicePath: '/tmp/fake',
+        },
+        service: {},
+      },
+    };
+
+    const result = wrapUtils.shouldWrap(ctx);
+
+    expect(result).to.be.false;
+    expect(fs.existsSync.calledWith('/tmp/fake/package.json')).to.be.true;
+    expect(fs.readFileSync.calledWith('/tmp/fake/package.json')).to.be.true;
+  });
+
+  it('evaluates custom.enterprise.disableWrapping when determining to not wrap service', () => {
+    const ctx = {
+      sls: {
+        config: {
+          servicePath: '/tmp/fake',
+        },
+        service: {
+          custom: {
+            enterprise: {
+              disableWrapping: true,
+            },
+          },
+        },
+      },
+    };
+
+    const result = wrapUtils.shouldWrap(ctx);
+
+    expect(result).to.be.false;
+    expect(fs.existsSync.notCalled).to.be.true;
+    expect(fs.readFileSync.notCalled).to.be.true;
+  });
+
+  it('evaluates package.json type when determining to wrap service', () => {
+    const ctx = {
+      sls: {
+        config: {
+          servicePath: '/tmp/fake',
+        },
+        service: {},
+      },
+    };
+
+    fs.readFileSync = sinon.stub().returns('{}');
+
+    const result = wrapUtils.shouldWrap(ctx);
+
+    expect(result).to.be.true;
+    expect(fs.existsSync.calledWith('/tmp/fake/package.json')).to.be.true;
+    expect(fs.readFileSync.calledWith('/tmp/fake/package.json')).to.be.true;
+  });
+
+  it('evaluates custom.enterprise.disableWrapping when determining to wrap service', () => {
+    const ctx = {
+      sls: {
+        config: {
+          servicePath: '/tmp/fake',
+        },
+        service: {
+          custom: {
+            enterprise: {
+              disableWrapping: false,
+            },
+          },
+        },
+      },
+    };
+
+    fs.readFileSync = sinon.stub().returns('{}');
+
+    const result = wrapUtils.shouldWrap(ctx);
+
+    expect(result).to.be.true;
+    expect(fs.existsSync.calledWith('/tmp/fake/package.json')).to.be.true;
+    expect(fs.readFileSync.calledWith('/tmp/fake/package.json')).to.be.true;
+  });
+
+  it('should wrap functions when runtime is python', () => {
+    const ctx = {
+      sls: {
+        config: {
+          servicePath: '/tmp/fake',
+        },
+        service: {
+          provider: {
+            runtime: 'python3.10',
+          },
+        },
+      },
+    };
+
+    const result = wrapUtils.shouldWrapFunction(ctx, {});
+    expect(result).to.be.true;
+    expect(fs.existsSync.notCalled).to.be.true;
+    expect(fs.readFileSync.notCalled).to.be.true;
+  });
+
+  it('should wrap functions when runtime is node and is a .js file', () => {
+    const ctx = {
+      sls: {
+        config: {
+          servicePath: '/tmp/fake',
+        },
+        service: {
+          provider: {
+            runtime: 'nodejs16.x',
+          },
+        },
+      },
+    };
+
+    const functionConfig = {
+      handler: 'src/index.handler',
+    };
+
+    fs.existsSync = sinon.stub().returns(true);
+
+    const result = wrapUtils.shouldWrapFunction(ctx, functionConfig);
+    expect(result).to.be.true;
+    expect(fs.existsSync.calledWith('/tmp/fake/src/index.js')).to.be.true;
+    expect(fs.readFileSync.notCalled).to.be.true;
+  });
+
+  it('should not wrap functions when runtime is node and is a .mjs file', () => {
+    const ctx = {
+      sls: {
+        config: {
+          servicePath: '/tmp/fake',
+        },
+        service: {
+          provider: {
+            runtime: 'nodejs16.x',
+          },
+        },
+      },
+    };
+
+    const functionConfig = {
+      handler: 'src/index.handler',
+    };
+
+    fs.existsSync = sinon.stub().onFirstCall().returns(false).onSecondCall().returns(true);
+
+    const result = wrapUtils.shouldWrapFunction(ctx, functionConfig);
+    expect(result).to.be.false;
+    expect(fs.existsSync.calledWith('/tmp/fake/src/index.js')).to.be.true;
+    expect(fs.existsSync.calledWith('/tmp/fake/src/index.mjs')).to.be.true;
+    expect(fs.readFileSync.notCalled).to.be.true;
+  });
+
+  it('should not wrap functions when a runtime is not supported', () => {
+    const ctx = {
+      sls: {
+        config: {
+          servicePath: '/tmp/fake',
+        },
+        service: {
+          provider: {
+            runtime: 'unsupported16.x',
+          },
+        },
+      },
+    };
+
+    const functionConfig = {
+      handler: 'src/index.handler',
+    };
+
+    fs.existsSync = sinon.stub().onFirstCall().returns(false).onSecondCall().returns(true);
+
+    const result = wrapUtils.shouldWrapFunction(ctx, functionConfig);
+    expect(result).to.be.false;
+    expect(fs.existsSync.notCalled).to.be.true;
+    expect(fs.existsSync.notCalled).to.be.true;
+    expect(fs.readFileSync.notCalled).to.be.true;
+  });
+});

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -14,11 +14,20 @@ const log = require('./log');
 const { getOrCreateAccessKeyForOrg } = require('./client-utils');
 const { addTree, writeZip } = require('./zip-tree');
 const { version } = require('../package.json');
+const { shouldWrap, shouldWrapFunction } = require('./wrap-utils');
 
 const deprecatedNodes = ['nodejs', 'nodejs4.3', 'nodejs4.3-edge'];
 const supportedNodeRuntime = (runtime) =>
   runtime && runtime.includes('nodejs') && !deprecatedNodes.includes(runtime);
-const supportedPythonRuntime = (runtime) => runtime && runtime.includes('python');
+const pythonRuntimes = [
+  'python2.7',
+  'python3.6',
+  'python3.7',
+  'python3.8',
+  'python3.9',
+  'python3.10',
+];
+const supportedPythonRuntime = (runtime) => runtime && pythonRuntimes.includes(runtime);
 const supportedRuntime = (runtime) =>
   supportedNodeRuntime(runtime) || supportedPythonRuntime(runtime);
 
@@ -258,6 +267,10 @@ except Exception as error:
 };
 
 const wrap = async (ctx) => {
+  if (!shouldWrap(ctx)) {
+    log.warning('Skipping Wrapping for Service');
+    return;
+  }
   /*
    * Prepare Functions
    */
@@ -280,6 +293,11 @@ const wrap = async (ctx) => {
       continue;
     }
 
+    if (!shouldWrapFunction(ctx, functionConfig)) {
+      log.warning(`Skipping wrapping for Function: ${func}`);
+      continue;
+    }
+
     // the default is 6s: https://serverless.com/framework/docs/providers/aws/guide/serverless.yml/
     const timeout = functionConfig.timeout || ctx.sls.service.provider.timeout || 6;
 
@@ -294,6 +312,7 @@ const wrap = async (ctx) => {
     // Process handler
     const entry = functionConfig.handler.split('.').slice(0, -1).join('.');
     const handler = functionConfig.handler.split('.').slice(-1)[0];
+
     let extension = 'js';
     if (runtime.includes('python')) {
       extension = 'py';
@@ -311,6 +330,7 @@ const wrap = async (ctx) => {
       handlerNew: 'handler',
     };
   }
+
   if (unsupportedRuntimes.size) {
     log.warning(
       `Serverless Dashboard monitoring features do not support the following runtime${

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -816,6 +816,7 @@ except Exception as error:
         'jszip': JSZip,
         './zip-tree': { addTree, writeZip },
         'fs-extra': fs,
+        './wrap-utils': wrapUtils,
         './client-utils': {
           getOrCreateAccessKeyForOrg: () => 'accesskey',
         },
@@ -854,6 +855,9 @@ except Exception as error:
           cli: { log },
         },
       };
+
+      wrapUtilsFs.readFileSync = sinon.stub().returns('{}');
+      wrapUtilsFs.existsSync = sinon.stub().returns(true);
       await wrap(ctx);
       expect(fs.writeFileSync.args[0][1]).to.include('studioHandler');
     });

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -128,6 +128,10 @@ describe('wrap - wrap', () => {
         },
       },
     };
+
+    wrapUtilsFs.readFileSync = sinon.stub().returns('{}');
+    wrapUtilsFs.existsSync = sinon.stub().returns(true);
+
     await wrap(ctx);
 
     expect(fs.pathExistsSync.calledWith(`path${path.sep}serverless_sdk`)).to.be.true;
@@ -709,6 +713,9 @@ except Exception as error:
         },
       },
     };
+
+    wrapUtilsFs.readFileSync = sinon.stub().returns('{"type": "module"}');
+
     await wrap(ctx);
     expect(ctx.state.functions).to.be.undefined;
     expect(Object.keys(ctx.state).length).to.equal(0);

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -49,6 +49,8 @@ const { version } = require('../package.json');
 
 describe('wrap - wrap', () => {
   let fs;
+  let wrapUtilsFs;
+  let wrapUtils;
   let wrap;
   let addTree;
   let writeZip;
@@ -70,10 +72,20 @@ describe('wrap - wrap', () => {
       }),
     };
 
+    wrapUtilsFs = {
+      readFileSync: sinon.stub().returns('{"type": "module"}'),
+      existsSync: sinon.stub().returns(true),
+    };
+
+    wrapUtils = proxyquire('./wrap-utils', {
+      'fs-extra': wrapUtilsFs,
+    });
+
     wrap = proxyquire('./wrap', {
       'jszip': JSZip,
       './zip-tree': { addTree, writeZip },
       'fs-extra': fs,
+      './wrap-utils': wrapUtils,
     });
   });
 
@@ -635,6 +647,154 @@ except Exception as error:
 `
       )
     ).to.be.true;
+  });
+
+  it('does not wrap service when custom.enterprise.disableWrapping is true', async () => {
+    const ctx = {
+      deploymentUid: 'deploymentUid',
+      state: {},
+      provider: { getStage: () => 'dev' },
+      sls: {
+        config: { servicePath: 'path' },
+        processedInput: { commands: [] },
+        service: {
+          service: 'service',
+          org: 'org',
+          app: 'app',
+          appUid: 'appUid',
+          orgUid: 'orgUid',
+          provider: { stage: 'dev', runtime: 'nodejs18.x', timeout: 10 },
+          custom: {
+            enterprise: {
+              disableWrapping: true,
+            },
+          },
+          functions: {
+            func: {
+              runtime: 'nodejs18.x',
+              handler: 'handlerFile.handlerFunc',
+              timeout: 6,
+            },
+          },
+        },
+      },
+    };
+    await wrap(ctx);
+    expect(ctx.state.functions).to.be.undefined;
+    expect(Object.keys(ctx.state).length).to.equal(0);
+  });
+
+  it('does not wrap service when package.json type is module is true', async () => {
+    const ctx = {
+      deploymentUid: 'deploymentUid',
+      state: {},
+      provider: { getStage: () => 'dev' },
+      sls: {
+        config: { servicePath: 'path' },
+        processedInput: { commands: [] },
+        service: {
+          service: 'service',
+          org: 'org',
+          app: 'app',
+          appUid: 'appUid',
+          orgUid: 'orgUid',
+          provider: { stage: 'dev', runtime: 'nodejs18.x', timeout: 10 },
+          functions: {
+            func: {
+              runtime: 'nodejs18.x',
+              handler: 'handlerFile.handlerFunc',
+              timeout: 6,
+            },
+          },
+        },
+      },
+    };
+    await wrap(ctx);
+    expect(ctx.state.functions).to.be.undefined;
+    expect(Object.keys(ctx.state).length).to.equal(0);
+  });
+
+  it('wraps cjs functions and does not wrap mjs functions', async () => {
+    const ctx = {
+      deploymentUid: 'deploymentUid',
+      state: {},
+      provider: { getStage: () => 'dev' },
+      sls: {
+        config: { servicePath: 'path' },
+        processedInput: { commands: [] },
+        service: {
+          service: 'service',
+          org: 'org',
+          app: 'app',
+          appUid: 'appUid',
+          orgUid: 'orgUid',
+          provider: { stage: 'dev', runtime: 'nodejs18.x', timeout: 10 },
+          functions: {
+            cjsFunc: {
+              runtime: 'nodejs18.x',
+              handler: 'handlerFile.handlerFunc',
+              timeout: 6,
+            },
+            mjsFunc: {
+              runtime: 'nodejs18.x',
+              handler: 'handlerFile.handlerFuncMjc',
+              timeout: 6,
+            },
+          },
+        },
+      },
+    };
+
+    wrapUtilsFs.existsSync = sinon
+      .stub()
+      .onCall(0)
+      .returns(false)
+      .onCall(1)
+      .returns(true)
+      .onCall(2)
+      .returns(false)
+      .onCall(3)
+      .returns(true);
+    await wrap(ctx);
+    expect(ctx.state.functions).to.not.be.undefined;
+    expect(Object.keys(ctx.state.functions)).to.deep.equal(['cjsFunc']);
+  });
+
+  it('does not wrap unsupported python versions', async () => {
+    const ctx = {
+      deploymentUid: 'deploymentUid',
+      state: {},
+      provider: { getStage: () => 'dev' },
+      sls: {
+        config: { servicePath: 'path' },
+        processedInput: { commands: [] },
+        service: {
+          service: 'service',
+          org: 'org',
+          app: 'app',
+          appUid: 'appUid',
+          orgUid: 'orgUid',
+          provider: { stage: 'dev', runtime: 'nodejs18.x', timeout: 10 },
+          functions: {
+            cjsFunc: {
+              runtime: 'nodejs18.x',
+              handler: 'handlerFile.handlerFunc',
+              timeout: 6,
+            },
+            python11Func: {
+              runtime: 'python3.11',
+              handler: 'handlerFile.python311',
+              timeout: 6,
+            },
+          },
+        },
+      },
+    };
+
+    wrapUtilsFs.existsSync = sinon.stub().onCall(0).returns(false).onCall(1).returns(true);
+    await wrap(ctx);
+    expect(ctx.state.functions).to.not.be.undefined;
+    expect(Object.keys(ctx.state.functions)).to.deep.equal(['cjsFunc']);
   });
 
   describe('dev mode', () => {

--- a/test/fixtures/aws-loggedin-monitored-service/serverless.yml
+++ b/test/fixtures/aws-loggedin-monitored-service/serverless.yml
@@ -1,5 +1,6 @@
 service: 'some-aws-service'
 provider: 'aws'
-
+dashboard:
+  disableMonitoring: true
 org: 'testinteractivecli'
 app: 'some-aws-service-app'


### PR DESCRIPTION
* Adds a property `custom.enterprise.disableWrapping` to allow users to disable wrapping manually.
* If in the services `package.json` `type` is set to `module`, do not wrap functions in that service.
* If any of the handlers are using the `.mjs` extension then do not wrap that function.
* If the runtime is `python3.11` or greater do not wrap as the wrapping does not work with versions greater than 3.10.