### PR TITLE
feat: Remove stackman dependency to enable the use of the native Node solution

### DIFF
--- a/sdk-js/package-lock.json
+++ b/sdk-js/package-lock.json
@@ -6,11 +6,9 @@
     "": {
       "dependencies": {
         "@serverless/platform-client": "^4.4.0",
-        "after-all-results": "^2.0.0",
         "flat": "^5.0.2",
         "lodash": "^4.17.21",
         "require-in-the-middle": "^5.1.0",
-        "stackman": "^4.0.1",
         "type": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -1059,11 +1057,6 @@
         "node": ">=6.0"
       }
     },
-    "node_modules/after-all-results": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/after-all-results/-/after-all-results-2.0.0.tgz",
-      "integrity": "sha1-asL8ICtQD4jaj09VMM+hAPTGotA="
-    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -1388,15 +1381,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
       "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg=="
-    },
-    "node_modules/async-cache": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/async-cache/-/async-cache-1.1.0.tgz",
-      "integrity": "sha1-SppaidBl7F2OUlS9nulrp2xTK1o=",
-      "deprecated": "No longer maintained. Use [lru-cache](http://npm.im/lru-cache) version 7.6 or higher, and provide an asynchronous `fetchMethod` option.",
-      "dependencies": {
-        "lru-cache": "^4.0.0"
-      }
     },
     "node_modules/async-each": {
       "version": "1.0.3",
@@ -3179,11 +3163,6 @@
         "errno": "cli.js"
       }
     },
-    "node_modules/error-callsites": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/error-callsites/-/error-callsites-2.0.3.tgz",
-      "integrity": "sha512-v036z4IEffZFE5kBkV5/F2MzhLnG0vuDyN+VXpzCf4yWXvX/1WJCI0A+TGTr8HWzBfCw5k8gr9rwAo09V+obTA=="
-    },
     "node_modules/es5-ext": {
       "version": "0.10.53",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
@@ -4793,17 +4772,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/in-publish": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
-      "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
-      "bin": {
-        "in-install": "in-install.js",
-        "in-publish": "in-publish.js",
-        "not-in-install": "not-in-install.js",
-        "not-in-publish": "not-in-publish.js"
-      }
-    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -5431,16 +5399,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/load-source-map": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/load-source-map/-/load-source-map-1.0.0.tgz",
-      "integrity": "sha1-MY9JkFzopwnft8w/FvPv47zx3QU=",
-      "dependencies": {
-        "in-publish": "^2.0.0",
-        "semver": "^5.3.0",
-        "source-map": "^0.5.6"
-      }
-    },
     "node_modules/loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -5618,15 +5576,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
       }
     },
     "node_modules/lru-queue": {
@@ -7021,11 +6970,6 @@
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -7553,6 +7497,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -7852,6 +7797,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7970,18 +7916,6 @@
       "dev": true,
       "dependencies": {
         "figgy-pudding": "^3.5.1"
-      }
-    },
-    "node_modules/stackman": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/stackman/-/stackman-4.0.1.tgz",
-      "integrity": "sha512-lntIge3BFEElgvpZT2ld5f4U+mF84fRtJ8vA3ymUVx1euVx43ZMkd09+5RWW4FmvYDFhZwPh1gvtdsdnJyF4Fg==",
-      "dependencies": {
-        "after-all-results": "^2.0.0",
-        "async-cache": "^1.1.0",
-        "debug": "^4.1.1",
-        "error-callsites": "^2.0.3",
-        "load-source-map": "^1.0.0"
       }
     },
     "node_modules/static-extend": {
@@ -9794,11 +9728,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -10800,11 +10729,6 @@
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
       "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg=="
     },
-    "after-all-results": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/after-all-results/-/after-all-results-2.0.0.tgz",
-      "integrity": "sha1-asL8ICtQD4jaj09VMM+hAPTGotA="
-    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -11069,14 +10993,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
       "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg=="
-    },
-    "async-cache": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/async-cache/-/async-cache-1.1.0.tgz",
-      "integrity": "sha1-SppaidBl7F2OUlS9nulrp2xTK1o=",
-      "requires": {
-        "lru-cache": "^4.0.0"
-      }
     },
     "async-each": {
       "version": "1.0.3",
@@ -12567,11 +12483,6 @@
         "prr": "~1.0.1"
       }
     },
-    "error-callsites": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/error-callsites/-/error-callsites-2.0.3.tgz",
-      "integrity": "sha512-v036z4IEffZFE5kBkV5/F2MzhLnG0vuDyN+VXpzCf4yWXvX/1WJCI0A+TGTr8HWzBfCw5k8gr9rwAo09V+obTA=="
-    },
     "es5-ext": {
       "version": "0.10.53",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
@@ -13834,11 +13745,6 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
-    "in-publish": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
-      "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ=="
-    },
     "indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -14337,16 +14243,6 @@
         }
       }
     },
-    "load-source-map": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/load-source-map/-/load-source-map-1.0.0.tgz",
-      "integrity": "sha1-MY9JkFzopwnft8w/FvPv47zx3QU=",
-      "requires": {
-        "in-publish": "^2.0.0",
-        "semver": "^5.3.0",
-        "source-map": "^0.5.6"
-      }
-    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -14498,15 +14394,6 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "dev": true
-    },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
     },
     "lru-queue": {
       "version": "0.1.0",
@@ -15626,11 +15513,6 @@
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
     "public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -16034,7 +15916,8 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
     },
     "serialize-javascript": {
       "version": "5.0.1",
@@ -16282,7 +16165,8 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -16385,18 +16269,6 @@
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1"
-      }
-    },
-    "stackman": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/stackman/-/stackman-4.0.1.tgz",
-      "integrity": "sha512-lntIge3BFEElgvpZT2ld5f4U+mF84fRtJ8vA3ymUVx1euVx43ZMkd09+5RWW4FmvYDFhZwPh1gvtdsdnJyF4Fg==",
-      "requires": {
-        "after-all-results": "^2.0.0",
-        "async-cache": "^1.1.0",
-        "debug": "^4.1.1",
-        "error-callsites": "^2.0.3",
-        "load-source-map": "^1.0.0"
       }
     },
     "static-extend": {
@@ -17892,11 +17764,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "16.2.0",

--- a/sdk-js/package.json
+++ b/sdk-js/package.json
@@ -8,11 +8,9 @@
   },
   "dependencies": {
     "@serverless/platform-client": "^4.4.0",
-    "after-all-results": "^2.0.0",
     "flat": "^5.0.2",
     "lodash": "^4.17.21",
     "require-in-the-middle": "^5.1.0",
-    "stackman": "^4.0.1",
     "type": "^2.5.0",
     "uuid": "^8.3.2"
   },

--- a/sdk-js/src/lib/parsers.js
+++ b/sdk-js/src/lib/parsers.js
@@ -1,47 +1,8 @@
 'use strict';
 
 const util = require('util');
-const afterAll = require('after-all-results');
-const stackman = require('stackman')();
 
 exports._MAX_HTTP_BODY_CHARS = 2048; // expose for testing purposes
-
-const mysqlErrorMsg = /(ER_[A-Z_]+): /;
-
-// Default `culprit` to the top of the stack or the highest non `library_frame`
-// frame if such exists
-function getCulprit(frames) {
-  if (frames.length === 0) {
-    return null;
-  }
-
-  let { filename } = frames[0];
-  let fnName = frames[0].function;
-  for (let n = 0; n < frames.length; n++) {
-    if (!frames[n].library_frame) {
-      ({ filename } = frames[n]);
-      fnName = frames[n].function;
-      break;
-    }
-  }
-
-  return filename ? `${fnName} (${filename})` : fnName;
-}
-
-function getModule(frames) {
-  if (frames.length === 0) {
-    return null;
-  }
-  const frame = frames[0];
-  if (!frame.library_frame) {
-    return null;
-  }
-  const match = frame.filename.match(/node_modules\/([^/]*)/);
-  if (!match) {
-    return null;
-  }
-  return match[1];
-}
 
 exports.parseMessage = function (msg) {
   const error = { log: {} };
@@ -63,105 +24,6 @@ exports.parseMessage = function (msg) {
   }
 
   return error;
-};
-
-exports.parseError = function (err, agent, cb) {
-  stackman.callsites(err, (_err, callsites) => {
-    if (_err) {
-      //   agent.logger.debug('error while getting error callsites: %s', _err.message)
-    }
-
-    const errorMsg = String(err.message);
-    const error = {
-      exception: {
-        message: errorMsg,
-        type: String(err.name),
-      },
-    };
-
-    if ('code' in err) {
-      error.exception.code = String(err.code);
-    } else {
-      // To provide better grouping of mysql errors that happens after the async
-      // boundery, we modify to exception type to include the custom mysql error
-      // type (e.g. ER_PARSE_ERROR)
-      const match = errorMsg.match(mysqlErrorMsg);
-      if (match) {
-        error.exception.code = match[1];
-      }
-    }
-
-    const props = stackman.properties(err);
-    if (props.code) {
-      delete props.code;
-    } // we already have it directly on the exception
-    if (Object.keys(props).length > 0) {
-      error.exception.attributes = props;
-    }
-
-    const next = afterAll((_, frames) => {
-      // As of now, parseCallsite suppresses errors internally, but even if
-      // they were passed on, we would want to suppress them here anyway
-
-      // Filter frames that don't have a pre / post context
-      // This is causing errors on the front end
-      frames = frames.filter((frame) => frame.post_context && frame.pre_context);
-
-      if (frames) {
-        const culprit = getCulprit(frames);
-        const module = getModule(frames);
-        if (culprit) {
-          error.culprit = culprit;
-        } // TODO: consider moving culprit to exception
-        if (module) {
-          error.exception.module = module;
-        } // TODO: consider if we should include this as it's not originally what module was intended for
-        error.exception.stacktrace = frames;
-      }
-
-      cb(null, error);
-    });
-
-    if (callsites) {
-      callsites.forEach((callsite) => {
-        exports.parseCallsite(callsite, true, null, next());
-      });
-    }
-  });
-};
-
-exports.parseCallsite = function (callsite, isError, agent, cb) {
-  const filename = callsite.getFileName();
-  const frame = {
-    filename: callsite.getRelativeFileName() || '',
-    lineno: callsite.getLineNumber(),
-    function: callsite.getFunctionNameSanitized(),
-    library_frame: !callsite.isApp(),
-  };
-  if (!Number.isFinite(frame.lineno)) {
-    frame.lineno = 0;
-  } // this should be an int, but sometimes it's not?! ¯\_(ツ)_/¯
-  if (filename) {
-    frame.abs_path = filename;
-  }
-
-  const lines = 5;
-  if (lines === 0 || callsite.isNode()) {
-    setImmediate(cb, null, frame);
-    return;
-  }
-
-  callsite.sourceContext(lines, (err, context) => {
-    if (err) {
-      console.debug('error while getting callsite source context: %s', err.message);
-    } else {
-      frame.pre_context = context.pre;
-      frame.context_line = context.line.slice(0, 100);
-      frame.post_context = context.post;
-    }
-
-    cb(null, frame);
-  });
 };
 
 module.exports.captureAwsRequestSpan = function (resp) {

--- a/sdk-js/src/lib/transaction.js
+++ b/sdk-js/src/lib/transaction.js
@@ -6,7 +6,6 @@
 
 const _ = require('lodash');
 const uuidv4 = require('uuid').v4;
-const { parseError } = require('./parsers');
 const flatten = require('flat');
 const isError = require('type/error/is');
 const zlib = require('zlib');
@@ -173,24 +172,12 @@ class Transaction {
       // Log
       console.info('');
       console.error(error);
-
-      parseError(error, null, (_res, errorStack) => {
-        this.set('error.culprit', errorStack.culprit);
-        this.set('error.fatal', fatal);
-        this.set('error.exception.type', errorStack.exception.type);
-        // sliced to 25 kb: 25 * 1024 / 8 = 3200
-        this.set(
-          'error.exception.message',
-          Buffer.from(errorStack.exception.message).slice(0, 3200).toString()
-        );
-        this.set('error.exception.stacktrace', JSON.stringify(errorStack.exception.stacktrace));
-
-        // End transaction
-        this.buildOutput(ERROR); // set this to transaction for now.
-        self.end();
-        // Resolve in next tick, so dashboard log is flushed before lambda invocation is closed
-        setTimeout(cb);
-      });
+      this.set('error.fatal', fatal);
+      // End transaction
+      this.buildOutput(ERROR); // set this to transaction for now.
+      self.end();
+      // Resolve in next tick, so dashboard log is flushed before lambda invocation is closed
+      setTimeout(cb);
     } else {
       // Create Error ID
       // since the user didn't actually thrown an error, just include it with a prefix


### PR DESCRIPTION
[stackman](https://github.com/watson/stackman) library collides with [--enable-source-maps](https://nodejs.dev/en/api/v20/cli/#--enable-source-maps) which is a native Node source map solution introduced as experimental in v12 and stable in v14. Stacktraces generated using [error.stack](https://nodejs.org/api/errors.html#errorstack) in wrapped functions don't use source maps (even with `--enable-source-maps` set) because of `stackman` dependency. This PR removes `stackman` and therefore enables the use of the native Node solution.